### PR TITLE
[FEAT] Docker 배포 관련 설정 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gradle
+out
+*.md
+*.env

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to EC2 via Docker
+
+on:
+  push:
+    branches:
+      - main  # main 브랜치에 push될 때만 배포
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 코드 체크아웃
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Docker Hub 로그인
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # Docker 이미지 빌드 & 푸시
+      - name: Build and push Docker image
+        run: |
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/haeil-app:latest .
+          docker push ${{ secrets.DOCKER_USERNAME }}/haeil-app:latest
+
+      # EC2에 SSH 접속 후 deploy.sh 실행
+      - name: Deploy to EC2
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_KEY }}
+          script: |
+            cd /home/ec2-user/BE
+            ./deploy.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# 실행용 경량 이미지
+FROM eclipse-temurin:17-jdk-focal
+
+WORKDIR /app
+
+# 로컬에서 빌드된 JAR 파일 복사
+COPY build/libs/*.jar app.jar
+
+# 컨테이너 실행
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# === 설정 부분 ===
+DOCKER_HUB_ID="dnglzl0823"         # Docker Hub ID
+IMAGE_NAME="haeil-app"             # 이미지 이름
+IMAGE_TAG="latest"                 # 이미지 태그
+CONTAINER_NAME="haeil-container"   # 컨테이너 이름
+PORT=8080                          # 서버 포트
+SPRING_PROFILE="prod"              # active profile
+
+# === 스크립트 위치 기준 경로 (스크립트가 어디서 실행되든 BE 폴더를 찾도록) ===
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/.env"
+
+# === .env 파일 확인 및 로드(또는 에러) ===
+if [ -f "$ENV_FILE" ]; then
+  echo "Using env file: $ENV_FILE"
+else
+  echo "ERROR: env file not found: $ENV_FILE"
+  echo "Put your RDS / SERVER env variables into $ENV_FILE and try again."
+  exit 1
+fi
+
+# === 기존 컨테이너 종료 및 삭제 (있으면) ===
+EXISTING=$(docker ps -a -q -f name="^/${CONTAINER_NAME}$")
+if [ -n "$EXISTING" ]; then
+  echo "Stopping and removing existing container: $CONTAINER_NAME"
+  docker stop "$CONTAINER_NAME" || true
+  docker rm "$CONTAINER_NAME" || true
+fi
+
+# === Docker Hub에서 최신 이미지 pull ===
+echo "Pulling image: $DOCKER_HUB_ID/$IMAGE_NAME:$IMAGE_TAG"
+docker pull "$DOCKER_HUB_ID/$IMAGE_NAME:$IMAGE_TAG"
+
+# === 새 컨테이너 실행 ===
+echo "Running container: $CONTAINER_NAME"
+docker run -d \
+  --name "$CONTAINER_NAME" \
+  -p "$PORT:$PORT" \
+  --env-file "$ENV_FILE" \
+  -e SPRING_PROFILES_ACTIVE="$SPRING_PROFILE" \
+  --restart unless-stopped \
+  "$DOCKER_HUB_ID/$IMAGE_NAME:$IMAGE_TAG"
+
+# === 완료 메시지 ===
+echo "Deployment finished."
+echo "To follow logs: docker logs -f $CONTAINER_NAME"
+echo "To check running containers: docker ps"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,6 +10,10 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
     show-sql: false
 
+swagger:
+  server:
+    url: ${SWAGGER_URL}
+
 server:
   port: ${SERVER_PORT}
 


### PR DESCRIPTION
## 🪺 개요 
- Spring Boot 애플리케이션의 Docker 이미지 빌드 및 배포 환경 설정 추가
- CI/CD 자동 배포를 위해 GitHub Actions 워크플로우 구성

## 💻 작업 사항 
- [x] Dockerfile 추가: 애플리케이션 빌드 및 컨테이너 실행 가능하도록 구성
- [x] .dockerignore 추가: 불필요한 파일 제외
- [x] application-prod.yml 파일 수정: swagger 관련 오류 해결을 위해 코드 추가 
- [x] deploy.sh 추가: EC2 서버 배포 자동화 스크립트
- [x] .github/workflows/deploy.yml 추가: GitHub Actions를 통한 빌드 및 배포 자동화

## 🌱 Issue Number
- #29 

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요 ?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요 ?
- [x] 테스트는 잘 통과했나요 ?
- [x] 빌드에 성공했나요 ?
- [x] 본인을 Assign 해주세요.
- [x] 리뷰할 팀원들을 Request 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙏 To Reviewers
> http://43.200.24.164:8080/swagger-ui/index.html 에서 확인하실 수 있습니다!
> -> 요금 때문에 우선 중지해두었습니다.
