### PR TITLE
[FEAT] 정산 관련 API 구현

### DIFF
--- a/src/main/java/com/haeil/be/settlement/controller/SettlementController.java
+++ b/src/main/java/com/haeil/be/settlement/controller/SettlementController.java
@@ -2,6 +2,7 @@ package com.haeil.be.settlement.controller;
 
 import com.haeil.be.global.response.ApiResponse;
 import com.haeil.be.settlement.dto.request.CreateSettlementRequest;
+import com.haeil.be.settlement.dto.request.UpdatePaymentStatusRequest;
 import com.haeil.be.settlement.dto.request.UpdateSettlementRequest;
 import com.haeil.be.settlement.dto.response.SettlementListResponse;
 import com.haeil.be.settlement.dto.response.SettlementResponse;
@@ -46,7 +47,7 @@ public class SettlementController {
         return ApiResponse.from(responses);
     }
 
-    @Operation(summary = "정산 상세 조회", description = "정산 상세 정보를 조회합니다.")
+    @Operation(summary = "정산서 조회", description = "정산서 상세 정보를 조회합니다.")
     @GetMapping("/{id}")
     public ApiResponse<Object> getSettlement(@PathVariable Long id) {
         SettlementResponse response = settlementService.getSettlement(id);
@@ -58,6 +59,15 @@ public class SettlementController {
     public ApiResponse<Object> updateSettlement(
             @PathVariable Long id, @Valid @RequestBody UpdateSettlementRequest request) {
         SettlementResponse response = settlementService.updateSettlement(id, request);
+        return ApiResponse.from(response);
+    }
+
+    @Operation(summary = "정산 상태 변경", description = "정산서의 결제 상태를 변경합니다.")
+    @PatchMapping("/{id}/payment-status")
+    public ApiResponse<Object> updatePaymentStatus(
+            @PathVariable Long id, @Valid @RequestBody UpdatePaymentStatusRequest request) {
+        SettlementResponse response =
+                settlementService.updatePaymentStatus(id, request.getPaymentStatus());
         return ApiResponse.from(response);
     }
 

--- a/src/main/java/com/haeil/be/settlement/controller/SettlementController.java
+++ b/src/main/java/com/haeil/be/settlement/controller/SettlementController.java
@@ -1,0 +1,71 @@
+package com.haeil.be.settlement.controller;
+
+import com.haeil.be.global.response.ApiResponse;
+import com.haeil.be.settlement.dto.request.CreateSettlementRequest;
+import com.haeil.be.settlement.dto.request.UpdateSettlementRequest;
+import com.haeil.be.settlement.dto.response.SettlementListResponse;
+import com.haeil.be.settlement.dto.response.SettlementResponse;
+import com.haeil.be.settlement.service.SettlementService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+// import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Settlement", description = "정산 관련 API")
+@RequestMapping("/api/v1/settlements")
+@RestController
+@RequiredArgsConstructor
+public class SettlementController {
+
+    private final SettlementService settlementService;
+
+    @Operation(summary = "정산 생성", description = "새로운 정산 정보를 생성합니다.")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<Object> createSettlement(
+            @Valid @RequestBody CreateSettlementRequest request) {
+        SettlementResponse response = settlementService.createSettlement(request);
+        return ApiResponse.from(response);
+    }
+
+    @Operation(summary = "정산 목록 조회", description = "완료된 사건 기준으로 정산 목록을 조회합니다. 정산서가 없는 사건도 포함됩니다.")
+    @GetMapping
+    public ApiResponse<Object> getSettlements() {
+        List<SettlementListResponse> responses = settlementService.getSettlements();
+        return ApiResponse.from(responses);
+    }
+
+    @Operation(summary = "정산 상세 조회", description = "정산 상세 정보를 조회합니다.")
+    @GetMapping("/{id}")
+    public ApiResponse<Object> getSettlement(@PathVariable Long id) {
+        SettlementResponse response = settlementService.getSettlement(id);
+        return ApiResponse.from(response);
+    }
+
+    @Operation(summary = "정산 수정", description = "정산 정보를 수정합니다.")
+    @PatchMapping("/{id}")
+    public ApiResponse<Object> updateSettlement(
+            @PathVariable Long id, @Valid @RequestBody UpdateSettlementRequest request) {
+        SettlementResponse response = settlementService.updateSettlement(id, request);
+        return ApiResponse.from(response);
+    }
+
+    // @Operation(summary = "정산 삭제", description = "정산 정보를 삭제합니다.")
+    // @DeleteMapping("/{id}")
+    // @ResponseStatus(HttpStatus.NO_CONTENT)
+    // public ApiResponse<Object> deleteSettlement(@PathVariable Long id) {
+    //     settlementService.deleteSettlement(id);
+    //     return ApiResponse.EMPTY_RESPONSE;
+    // }
+}

--- a/src/main/java/com/haeil/be/settlement/domain/Settlement.java
+++ b/src/main/java/com/haeil/be/settlement/domain/Settlement.java
@@ -48,9 +48,9 @@ public class Settlement extends BaseEntity {
     @Column(name = "note", columnDefinition = "TEXT")
     private String note;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "case_id")
-    private Cases relatedCase;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "case_id", unique = true)
+    private Cases cases;
 
     @Builder
     public Settlement(
@@ -63,7 +63,7 @@ public class Settlement extends BaseEntity {
             LocalDate settlementDate,
             LocalDate dueDate,
             String note,
-            Cases relatedCase) {
+            Cases cases) {
         this.paymentStatus = paymentStatus;
         this.lawyerFee = lawyerFee;
         this.total = total;
@@ -73,7 +73,7 @@ public class Settlement extends BaseEntity {
         this.settlementDate = settlementDate;
         this.dueDate = dueDate;
         this.note = note;
-        this.relatedCase = relatedCase;
+        this.cases = cases;
     }
 
     /**

--- a/src/main/java/com/haeil/be/settlement/domain/Settlement.java
+++ b/src/main/java/com/haeil/be/settlement/domain/Settlement.java
@@ -1,0 +1,175 @@
+package com.haeil.be.settlement.domain;
+
+import com.haeil.be.cases.domain.Cases;
+import com.haeil.be.global.entity.BaseEntity;
+import com.haeil.be.settlement.domain.type.PaymentStatus;
+import jakarta.persistence.*;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "settlements")
+@Entity
+@Getter
+@NoArgsConstructor
+public class Settlement extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_status", nullable = false)
+    private PaymentStatus paymentStatus;
+
+    @Column(name = "lawyer_fee", nullable = false, precision = 19, scale = 2)
+    private BigDecimal lawyerFee;
+
+    @Column(name = "total", nullable = false, precision = 19, scale = 2)
+    private BigDecimal total;
+
+    @Column(name = "expenses", nullable = false, precision = 19, scale = 2)
+    private BigDecimal expenses;
+
+    @Column(name = "is_vat_included", nullable = false)
+    private Boolean isVatIncluded = false;
+
+    @Column(name = "client_receivable", nullable = false, precision = 19, scale = 2)
+    private BigDecimal clientReceivable;
+
+    @Column(name = "settlement_date")
+    private LocalDate settlementDate;
+
+    @Column(name = "due_date", nullable = false)
+    private LocalDate dueDate;
+
+    @Column(name = "note", columnDefinition = "TEXT")
+    private String note;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "case_id")
+    private Cases relatedCase;
+
+    @Builder
+    public Settlement(
+            PaymentStatus paymentStatus,
+            BigDecimal lawyerFee,
+            BigDecimal total,
+            BigDecimal expenses,
+            Boolean isVatIncluded,
+            BigDecimal clientReceivable,
+            LocalDate settlementDate,
+            LocalDate dueDate,
+            String note,
+            Cases relatedCase) {
+        this.paymentStatus = paymentStatus;
+        this.lawyerFee = lawyerFee;
+        this.total = total;
+        this.expenses = expenses;
+        this.isVatIncluded = isVatIncluded != null ? isVatIncluded : false;
+        this.clientReceivable = clientReceivable;
+        this.settlementDate = settlementDate;
+        this.dueDate = dueDate;
+        this.note = note;
+        this.relatedCase = relatedCase;
+    }
+
+    /**
+     * 정산 정보를 업데이트합니다.
+     *
+     * @param paymentStatus 결제 상태
+     * @param lawyerFee 변호사 수임료
+     * @param total 총액
+     * @param expenses 경비
+     * @param isVatIncluded VAT 포함 여부
+     * @param clientReceivable 의뢰인 미수금
+     * @param settlementDate 정산일
+     * @param dueDate 만료일
+     * @param note 비고
+     */
+    public void update(
+            PaymentStatus paymentStatus,
+            BigDecimal lawyerFee,
+            BigDecimal total,
+            BigDecimal expenses,
+            Boolean isVatIncluded,
+            BigDecimal clientReceivable,
+            LocalDate settlementDate,
+            LocalDate dueDate,
+            String note) {
+        if (paymentStatus != null) {
+            this.changePaymentStatus(paymentStatus);
+        }
+        if (lawyerFee != null) {
+            this.lawyerFee = lawyerFee;
+        }
+        if (total != null) {
+            this.total = total;
+        }
+        if (expenses != null) {
+            this.expenses = expenses;
+        }
+        if (isVatIncluded != null) {
+            this.isVatIncluded = isVatIncluded;
+        }
+        if (clientReceivable != null) {
+            this.clientReceivable = clientReceivable;
+        }
+        if (settlementDate != null) {
+            this.settlementDate = settlementDate;
+        }
+        if (dueDate != null) {
+            this.dueDate = dueDate;
+        }
+        if (note != null) {
+            this.note = note;
+        }
+
+        // 금액이 변경된 경우 clientReceivable 재계산
+        if (lawyerFee != null || expenses != null || isVatIncluded != null) {
+            this.recalculateClientReceivable();
+        }
+    }
+
+    /**
+     * clientReceivable을 계산합니다. VAT 포함 여부에 따라 10% 부가세를 반영합니다.
+     *
+     * @param lawyerFee 변호사 수임료
+     * @param expenses 경비
+     * @param isVatIncluded VAT 포함 여부
+     * @return 계산된 의뢰인 미수금
+     */
+    public static BigDecimal calculateClientReceivable(
+            BigDecimal lawyerFee, BigDecimal expenses, Boolean isVatIncluded) {
+        BigDecimal subtotal = lawyerFee.add(expenses);
+
+        if (Boolean.TRUE.equals(isVatIncluded)) {
+            // VAT 10% 포함
+            BigDecimal vat = subtotal.multiply(new BigDecimal("0.1"));
+            return subtotal.add(vat);
+        } else {
+            // VAT 미포함
+            return subtotal;
+        }
+    }
+
+    /** clientReceivable을 재계산하여 업데이트합니다. */
+    public void recalculateClientReceivable() {
+        this.clientReceivable =
+                calculateClientReceivable(this.lawyerFee, this.expenses, this.isVatIncluded);
+    }
+
+    /**
+     * paymentStatus를 변경합니다.
+     *
+     * @param newStatus 변경할 결제 상태
+     */
+    public void changePaymentStatus(PaymentStatus newStatus) {
+        if (newStatus == null) {
+            throw new IllegalArgumentException("결제 상태는 null일 수 없습니다.");
+        }
+        this.paymentStatus = newStatus;
+    }
+}

--- a/src/main/java/com/haeil/be/settlement/domain/Settlement.java
+++ b/src/main/java/com/haeil/be/settlement/domain/Settlement.java
@@ -3,6 +3,7 @@ package com.haeil.be.settlement.domain;
 import com.haeil.be.cases.domain.Cases;
 import com.haeil.be.global.entity.BaseEntity;
 import com.haeil.be.settlement.domain.type.PaymentStatus;
+import com.haeil.be.settlement.domain.type.SettlementStatus;
 import jakarta.persistence.*;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -24,26 +25,30 @@ public class Settlement extends BaseEntity {
     @Column(name = "payment_status", nullable = false)
     private PaymentStatus paymentStatus;
 
-    @Column(name = "lawyer_fee", nullable = false, precision = 19, scale = 2)
-    private BigDecimal lawyerFee;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "settlement_status", nullable = false)
+    private SettlementStatus settlementStatus = SettlementStatus.NONE;
 
-    @Column(name = "total", nullable = false, precision = 19, scale = 2)
-    private BigDecimal total;
+    @Column(name = "attorney_fee", precision = 19, scale = 2)
+    private BigDecimal attorneyFee;
 
-    @Column(name = "expenses", nullable = false, precision = 19, scale = 2)
+    @Column(name = "agreement_amount", precision = 19, scale = 2)
+    private BigDecimal agreementAmount;
+
+    @Column(name = "expenses", precision = 19, scale = 2)
     private BigDecimal expenses;
 
     @Column(name = "is_vat_included", nullable = false)
     private Boolean isVatIncluded = false;
 
-    @Column(name = "client_receivable", nullable = false, precision = 19, scale = 2)
+    @Column(name = "client_receivable", precision = 19, scale = 2)
     private BigDecimal clientReceivable;
 
     @Column(name = "settlement_date")
     private LocalDate settlementDate;
 
-    @Column(name = "due_date", nullable = false)
-    private LocalDate dueDate;
+    @Column(name = "payment_due_date")
+    private LocalDate paymentDueDate;
 
     @Column(name = "note", columnDefinition = "TEXT")
     private String note;
@@ -55,23 +60,25 @@ public class Settlement extends BaseEntity {
     @Builder
     public Settlement(
             PaymentStatus paymentStatus,
-            BigDecimal lawyerFee,
-            BigDecimal total,
+            SettlementStatus settlementStatus,
+            BigDecimal attorneyFee,
+            BigDecimal agreementAmount,
             BigDecimal expenses,
             Boolean isVatIncluded,
             BigDecimal clientReceivable,
             LocalDate settlementDate,
-            LocalDate dueDate,
+            LocalDate paymentDueDate,
             String note,
             Cases cases) {
         this.paymentStatus = paymentStatus;
-        this.lawyerFee = lawyerFee;
-        this.total = total;
+        this.settlementStatus = settlementStatus != null ? settlementStatus : SettlementStatus.NONE;
+        this.attorneyFee = attorneyFee;
+        this.agreementAmount = agreementAmount;
         this.expenses = expenses;
         this.isVatIncluded = isVatIncluded != null ? isVatIncluded : false;
         this.clientReceivable = clientReceivable;
         this.settlementDate = settlementDate;
-        this.dueDate = dueDate;
+        this.paymentDueDate = paymentDueDate;
         this.note = note;
         this.cases = cases;
     }
@@ -79,29 +86,29 @@ public class Settlement extends BaseEntity {
     /**
      * 정산 정보를 업데이트합니다.
      *
-     * @param lawyerFee 변호사 수임료
-     * @param total 총액
+     * @param attorneyFee 변호사 보수
+     * @param agreementAmount 합의금 총액
      * @param expenses 경비
      * @param isVatIncluded VAT 포함 여부
      * @param clientReceivable 의뢰인 미수금
-     * @param settlementDate 정산일
-     * @param dueDate 만료일
+     * @param settlementDate 합의일자
+     * @param paymentDueDate 입금기한
      * @param note 비고
      */
     public void update(
-            BigDecimal lawyerFee,
-            BigDecimal total,
+            BigDecimal attorneyFee,
+            BigDecimal agreementAmount,
             BigDecimal expenses,
             Boolean isVatIncluded,
             BigDecimal clientReceivable,
             LocalDate settlementDate,
-            LocalDate dueDate,
+            LocalDate paymentDueDate,
             String note) {
-        if (lawyerFee != null) {
-            this.lawyerFee = lawyerFee;
+        if (attorneyFee != null) {
+            this.attorneyFee = attorneyFee;
         }
-        if (total != null) {
-            this.total = total;
+        if (agreementAmount != null) {
+            this.agreementAmount = agreementAmount;
         }
         if (expenses != null) {
             this.expenses = expenses;
@@ -115,35 +122,88 @@ public class Settlement extends BaseEntity {
         if (settlementDate != null) {
             this.settlementDate = settlementDate;
         }
-        if (dueDate != null) {
-            this.dueDate = dueDate;
+        if (paymentDueDate != null) {
+            this.paymentDueDate = paymentDueDate;
         }
         if (note != null) {
             this.note = note;
         }
 
+        // 상태 변경 규칙 적용
+        updateSettlementStatus();
+
         // 금액이 변경된 경우 clientReceivable 재계산
-        if (total != null || lawyerFee != null || expenses != null || isVatIncluded != null) {
+        if (agreementAmount != null
+                || attorneyFee != null
+                || expenses != null
+                || isVatIncluded != null) {
             this.recalculateClientReceivable();
         }
     }
 
     /**
-     * clientReceivable을 계산합니다. 공식: clientReceivable = total - (lawyerFee + expenses + VAT) VAT =
-     * (lawyerFee + expenses) * 0.1
+     * 정산서 상태를 자동으로 업데이트합니다. - NONE → DRAFT: 어떤 필드든 값이 입력되면 - DRAFT → FINAL: attorneyFee,
+     * agreementAmount, expenses, paymentDueDate 모두 채워지면
+     */
+    public void updateSettlementStatus() {
+        // NONE → DRAFT: 어떤 필드든 값이 입력되면
+        if (this.settlementStatus == SettlementStatus.NONE) {
+            if (hasAnyFieldValue()) {
+                this.settlementStatus = SettlementStatus.DRAFT;
+            }
+            return;
+        }
+
+        // DRAFT → FINAL: 필수 필드 모두 채워지면
+        if (this.settlementStatus == SettlementStatus.DRAFT) {
+            if (isAllRequiredFieldsFilled()) {
+                this.settlementStatus = SettlementStatus.FINAL;
+            }
+        }
+    }
+
+    /** 어떤 필드든 값이 입력되었는지 확인합니다. */
+    private boolean hasAnyFieldValue() {
+        return attorneyFee != null
+                || agreementAmount != null
+                || expenses != null
+                || settlementDate != null
+                || paymentDueDate != null;
+        // || (note != null && !note.trim().isEmpty());
+    }
+
+    /** FINAL 상태로 변경하기 위한 필수 필드가 모두 채워졌는지 확인합니다. */
+    private boolean isAllRequiredFieldsFilled() {
+        return attorneyFee != null
+                && agreementAmount != null
+                && expenses != null
+                && paymentDueDate != null;
+    }
+
+    /**
+     * clientReceivable을 계산합니다. 공식: clientReceivable = agreementAmount - (attorneyFee + expenses +
+     * VAT) VAT = (attorneyFee + expenses) * 0.1
      *
-     * @param total 합의금 전체 금액
-     * @param lawyerFee 변호사 보수
+     * @param agreementAmount 합의금 전체 금액
+     * @param attorneyFee 변호사 보수
      * @param expenses 실비
      * @param isVatIncluded VAT 포함 여부
      * @return 계산된 의뢰인 최종 수령액
      */
     public static BigDecimal calculateClientReceivable(
-            BigDecimal total, BigDecimal lawyerFee, BigDecimal expenses, Boolean isVatIncluded) {
-        // 변호사 보수 + 실비
-        BigDecimal subtotal = lawyerFee.add(expenses);
+            BigDecimal agreementAmount,
+            BigDecimal attorneyFee,
+            BigDecimal expenses,
+            Boolean isVatIncluded) {
+        // 필수 필드가 null이면 null 반환
+        if (agreementAmount == null || attorneyFee == null || expenses == null) {
+            return null;
+        }
 
-        // VAT 계산: (lawyerFee + expenses) * 0.1
+        // 변호사 보수 + 실비
+        BigDecimal subtotal = attorneyFee.add(expenses);
+
+        // VAT 계산: (attorneyFee + expenses) * 0.1
         BigDecimal vat = subtotal.multiply(new BigDecimal("0.1"));
 
         // VAT 포함 여부에 따라 차감 금액 결정
@@ -156,15 +216,15 @@ public class Settlement extends BaseEntity {
             deduction = subtotal;
         }
 
-        // clientReceivable = total - deduction
-        return total.subtract(deduction);
+        // clientReceivable = agreementAmount - deduction
+        return agreementAmount.subtract(deduction);
     }
 
     /** clientReceivable을 재계산하여 업데이트합니다. */
     public void recalculateClientReceivable() {
         this.clientReceivable =
                 calculateClientReceivable(
-                        this.total, this.lawyerFee, this.expenses, this.isVatIncluded);
+                        this.agreementAmount, this.attorneyFee, this.expenses, this.isVatIncluded);
     }
 
     /**

--- a/src/main/java/com/haeil/be/settlement/domain/Settlement.java
+++ b/src/main/java/com/haeil/be/settlement/domain/Settlement.java
@@ -79,7 +79,6 @@ public class Settlement extends BaseEntity {
     /**
      * 정산 정보를 업데이트합니다.
      *
-     * @param paymentStatus 결제 상태
      * @param lawyerFee 변호사 수임료
      * @param total 총액
      * @param expenses 경비
@@ -90,7 +89,6 @@ public class Settlement extends BaseEntity {
      * @param note 비고
      */
     public void update(
-            PaymentStatus paymentStatus,
             BigDecimal lawyerFee,
             BigDecimal total,
             BigDecimal expenses,
@@ -99,9 +97,6 @@ public class Settlement extends BaseEntity {
             LocalDate settlementDate,
             LocalDate dueDate,
             String note) {
-        if (paymentStatus != null) {
-            this.changePaymentStatus(paymentStatus);
-        }
         if (lawyerFee != null) {
             this.lawyerFee = lawyerFee;
         }

--- a/src/main/java/com/haeil/be/settlement/domain/type/PaymentStatus.java
+++ b/src/main/java/com/haeil/be/settlement/domain/type/PaymentStatus.java
@@ -1,0 +1,16 @@
+package com.haeil.be.settlement.domain.type;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum PaymentStatus {
+    // REQUEST("수임요청"),
+    PENDING("임금대기"),
+    COMPLETED("입금완료");
+
+    private final String label;
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/main/java/com/haeil/be/settlement/domain/type/SettlementStatus.java
+++ b/src/main/java/com/haeil/be/settlement/domain/type/SettlementStatus.java
@@ -1,0 +1,16 @@
+package com.haeil.be.settlement.domain.type;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum SettlementStatus {
+    NONE("미작성"),
+    DRAFT("작성중"),
+    FINAL("작성완료");
+
+    private final String label;
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/main/java/com/haeil/be/settlement/dto/request/CreateSettlementRequest.java
+++ b/src/main/java/com/haeil/be/settlement/dto/request/CreateSettlementRequest.java
@@ -1,0 +1,65 @@
+package com.haeil.be.settlement.dto.request;
+
+import com.haeil.be.settlement.domain.type.PaymentStatus;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateSettlementRequest {
+
+    @NotNull(message = "결제 상태는 필수 입력 항목입니다.")
+    private PaymentStatus paymentStatus;
+
+    @NotNull(message = "변호사 수임료는 필수 입력 항목입니다.")
+    private BigDecimal lawyerFee;
+
+    @NotNull(message = "총액은 필수 입력 항목입니다.")
+    private BigDecimal total;
+
+    @NotNull(message = "경비는 필수 입력 항목입니다.")
+    private BigDecimal expenses;
+
+    private Boolean isVatIncluded = false;
+
+    @NotNull(message = "의뢰인 미수금은 필수 입력 항목입니다.")
+    private BigDecimal clientReceivable;
+
+    private LocalDate settlementDate;
+
+    @NotNull(message = "만료일은 필수 입력 항목입니다.")
+    private LocalDate dueDate;
+
+    private String note;
+
+    @NotNull(message = "사건 ID는 필수 입력 항목입니다.")
+    private Long caseId;
+
+    @Builder
+    public CreateSettlementRequest(
+            PaymentStatus paymentStatus,
+            BigDecimal lawyerFee,
+            BigDecimal total,
+            BigDecimal expenses,
+            Boolean isVatIncluded,
+            BigDecimal clientReceivable,
+            LocalDate settlementDate,
+            LocalDate dueDate,
+            String note,
+            Long caseId) {
+        this.paymentStatus = paymentStatus;
+        this.lawyerFee = lawyerFee;
+        this.total = total;
+        this.expenses = expenses;
+        this.isVatIncluded = isVatIncluded;
+        this.clientReceivable = clientReceivable;
+        this.settlementDate = settlementDate;
+        this.dueDate = dueDate;
+        this.note = note;
+        this.caseId = caseId;
+    }
+}

--- a/src/main/java/com/haeil/be/settlement/dto/request/CreateSettlementRequest.java
+++ b/src/main/java/com/haeil/be/settlement/dto/request/CreateSettlementRequest.java
@@ -11,24 +11,19 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CreateSettlementRequest {
 
-    @NotNull(message = "변호사 수임료는 필수 입력 항목입니다.")
-    private BigDecimal lawyerFee;
+    private BigDecimal attorneyFee;
 
-    @NotNull(message = "총액은 필수 입력 항목입니다.")
-    private BigDecimal total;
+    private BigDecimal agreementAmount;
 
-    @NotNull(message = "경비는 필수 입력 항목입니다.")
     private BigDecimal expenses;
 
     private Boolean isVatIncluded = false;
 
-    @NotNull(message = "의뢰인 미수금은 필수 입력 항목입니다.")
     private BigDecimal clientReceivable;
 
     private LocalDate settlementDate;
 
-    @NotNull(message = "만료일은 필수 입력 항목입니다.")
-    private LocalDate dueDate;
+    private LocalDate paymentDueDate;
 
     private String note;
 
@@ -37,22 +32,22 @@ public class CreateSettlementRequest {
 
     @Builder
     public CreateSettlementRequest(
-            BigDecimal lawyerFee,
-            BigDecimal total,
+            BigDecimal attorneyFee,
+            BigDecimal agreementAmount,
             BigDecimal expenses,
             Boolean isVatIncluded,
             BigDecimal clientReceivable,
             LocalDate settlementDate,
-            LocalDate dueDate,
+            LocalDate paymentDueDate,
             String note,
             Long caseId) {
-        this.lawyerFee = lawyerFee;
-        this.total = total;
+        this.attorneyFee = attorneyFee;
+        this.agreementAmount = agreementAmount;
         this.expenses = expenses;
         this.isVatIncluded = isVatIncluded;
         this.clientReceivable = clientReceivable;
         this.settlementDate = settlementDate;
-        this.dueDate = dueDate;
+        this.paymentDueDate = paymentDueDate;
         this.note = note;
         this.caseId = caseId;
     }

--- a/src/main/java/com/haeil/be/settlement/dto/request/CreateSettlementRequest.java
+++ b/src/main/java/com/haeil/be/settlement/dto/request/CreateSettlementRequest.java
@@ -1,6 +1,5 @@
 package com.haeil.be.settlement.dto.request;
 
-import com.haeil.be.settlement.domain.type.PaymentStatus;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -11,9 +10,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class CreateSettlementRequest {
-
-    @NotNull(message = "결제 상태는 필수 입력 항목입니다.")
-    private PaymentStatus paymentStatus;
 
     @NotNull(message = "변호사 수임료는 필수 입력 항목입니다.")
     private BigDecimal lawyerFee;
@@ -41,7 +37,6 @@ public class CreateSettlementRequest {
 
     @Builder
     public CreateSettlementRequest(
-            PaymentStatus paymentStatus,
             BigDecimal lawyerFee,
             BigDecimal total,
             BigDecimal expenses,
@@ -51,7 +46,6 @@ public class CreateSettlementRequest {
             LocalDate dueDate,
             String note,
             Long caseId) {
-        this.paymentStatus = paymentStatus;
         this.lawyerFee = lawyerFee;
         this.total = total;
         this.expenses = expenses;

--- a/src/main/java/com/haeil/be/settlement/dto/request/CreateSettlementRequest.java
+++ b/src/main/java/com/haeil/be/settlement/dto/request/CreateSettlementRequest.java
@@ -19,8 +19,6 @@ public class CreateSettlementRequest {
 
     private Boolean isVatIncluded = false;
 
-    private BigDecimal clientReceivable;
-
     private LocalDate settlementDate;
 
     private LocalDate paymentDueDate;
@@ -36,7 +34,6 @@ public class CreateSettlementRequest {
             BigDecimal agreementAmount,
             BigDecimal expenses,
             Boolean isVatIncluded,
-            BigDecimal clientReceivable,
             LocalDate settlementDate,
             LocalDate paymentDueDate,
             String note,
@@ -45,7 +42,6 @@ public class CreateSettlementRequest {
         this.agreementAmount = agreementAmount;
         this.expenses = expenses;
         this.isVatIncluded = isVatIncluded;
-        this.clientReceivable = clientReceivable;
         this.settlementDate = settlementDate;
         this.paymentDueDate = paymentDueDate;
         this.note = note;

--- a/src/main/java/com/haeil/be/settlement/dto/request/UpdatePaymentStatusRequest.java
+++ b/src/main/java/com/haeil/be/settlement/dto/request/UpdatePaymentStatusRequest.java
@@ -1,0 +1,20 @@
+package com.haeil.be.settlement.dto.request;
+
+import com.haeil.be.settlement.domain.type.PaymentStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdatePaymentStatusRequest {
+
+    @NotNull(message = "결제 상태는 필수 입력 항목입니다.")
+    private PaymentStatus paymentStatus;
+
+    @Builder
+    public UpdatePaymentStatusRequest(PaymentStatus paymentStatus) {
+        this.paymentStatus = paymentStatus;
+    }
+}

--- a/src/main/java/com/haeil/be/settlement/dto/request/UpdateSettlementRequest.java
+++ b/src/main/java/com/haeil/be/settlement/dto/request/UpdateSettlementRequest.java
@@ -1,6 +1,5 @@
 package com.haeil.be.settlement.dto.request;
 
-import com.haeil.be.settlement.domain.type.PaymentStatus;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import lombok.Builder;
@@ -11,7 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UpdateSettlementRequest {
 
-    private PaymentStatus paymentStatus;
     private BigDecimal lawyerFee;
     private BigDecimal total;
     private BigDecimal expenses;
@@ -23,7 +21,6 @@ public class UpdateSettlementRequest {
 
     @Builder
     public UpdateSettlementRequest(
-            PaymentStatus paymentStatus,
             BigDecimal lawyerFee,
             BigDecimal total,
             BigDecimal expenses,
@@ -32,7 +29,6 @@ public class UpdateSettlementRequest {
             LocalDate settlementDate,
             LocalDate dueDate,
             String note) {
-        this.paymentStatus = paymentStatus;
         this.lawyerFee = lawyerFee;
         this.total = total;
         this.expenses = expenses;

--- a/src/main/java/com/haeil/be/settlement/dto/request/UpdateSettlementRequest.java
+++ b/src/main/java/com/haeil/be/settlement/dto/request/UpdateSettlementRequest.java
@@ -1,0 +1,45 @@
+package com.haeil.be.settlement.dto.request;
+
+import com.haeil.be.settlement.domain.type.PaymentStatus;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateSettlementRequest {
+
+    private PaymentStatus paymentStatus;
+    private BigDecimal lawyerFee;
+    private BigDecimal total;
+    private BigDecimal expenses;
+    private Boolean isVatIncluded;
+    private BigDecimal clientReceivable;
+    private LocalDate settlementDate;
+    private LocalDate dueDate;
+    private String note;
+
+    @Builder
+    public UpdateSettlementRequest(
+            PaymentStatus paymentStatus,
+            BigDecimal lawyerFee,
+            BigDecimal total,
+            BigDecimal expenses,
+            Boolean isVatIncluded,
+            BigDecimal clientReceivable,
+            LocalDate settlementDate,
+            LocalDate dueDate,
+            String note) {
+        this.paymentStatus = paymentStatus;
+        this.lawyerFee = lawyerFee;
+        this.total = total;
+        this.expenses = expenses;
+        this.isVatIncluded = isVatIncluded;
+        this.clientReceivable = clientReceivable;
+        this.settlementDate = settlementDate;
+        this.dueDate = dueDate;
+        this.note = note;
+    }
+}

--- a/src/main/java/com/haeil/be/settlement/dto/request/UpdateSettlementRequest.java
+++ b/src/main/java/com/haeil/be/settlement/dto/request/UpdateSettlementRequest.java
@@ -14,7 +14,6 @@ public class UpdateSettlementRequest {
     private BigDecimal agreementAmount;
     private BigDecimal expenses;
     private Boolean isVatIncluded;
-    private BigDecimal clientReceivable;
     private LocalDate settlementDate;
     private LocalDate paymentDueDate;
     private String note;
@@ -25,7 +24,6 @@ public class UpdateSettlementRequest {
             BigDecimal agreementAmount,
             BigDecimal expenses,
             Boolean isVatIncluded,
-            BigDecimal clientReceivable,
             LocalDate settlementDate,
             LocalDate paymentDueDate,
             String note) {
@@ -33,7 +31,6 @@ public class UpdateSettlementRequest {
         this.agreementAmount = agreementAmount;
         this.expenses = expenses;
         this.isVatIncluded = isVatIncluded;
-        this.clientReceivable = clientReceivable;
         this.settlementDate = settlementDate;
         this.paymentDueDate = paymentDueDate;
         this.note = note;

--- a/src/main/java/com/haeil/be/settlement/dto/request/UpdateSettlementRequest.java
+++ b/src/main/java/com/haeil/be/settlement/dto/request/UpdateSettlementRequest.java
@@ -10,32 +10,32 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UpdateSettlementRequest {
 
-    private BigDecimal lawyerFee;
-    private BigDecimal total;
+    private BigDecimal attorneyFee;
+    private BigDecimal agreementAmount;
     private BigDecimal expenses;
     private Boolean isVatIncluded;
     private BigDecimal clientReceivable;
     private LocalDate settlementDate;
-    private LocalDate dueDate;
+    private LocalDate paymentDueDate;
     private String note;
 
     @Builder
     public UpdateSettlementRequest(
-            BigDecimal lawyerFee,
-            BigDecimal total,
+            BigDecimal attorneyFee,
+            BigDecimal agreementAmount,
             BigDecimal expenses,
             Boolean isVatIncluded,
             BigDecimal clientReceivable,
             LocalDate settlementDate,
-            LocalDate dueDate,
+            LocalDate paymentDueDate,
             String note) {
-        this.lawyerFee = lawyerFee;
-        this.total = total;
+        this.attorneyFee = attorneyFee;
+        this.agreementAmount = agreementAmount;
         this.expenses = expenses;
         this.isVatIncluded = isVatIncluded;
         this.clientReceivable = clientReceivable;
         this.settlementDate = settlementDate;
-        this.dueDate = dueDate;
+        this.paymentDueDate = paymentDueDate;
         this.note = note;
     }
 }

--- a/src/main/java/com/haeil/be/settlement/dto/response/SettlementListResponse.java
+++ b/src/main/java/com/haeil/be/settlement/dto/response/SettlementListResponse.java
@@ -16,8 +16,8 @@ public class SettlementListResponse {
     private String caseTitle;
     private Long settlementId;
     private PaymentStatus paymentStatus;
-    private BigDecimal total;
-    private LocalDate dueDate;
+    private BigDecimal agreementAmount;
+    private LocalDate paymentDueDate;
 
     /**
      * Repository에서 반환된 Object[] 결과를 SettlementListResponse로 변환합니다. Object[]의 첫 번째 요소는 Cases, 두 번째
@@ -35,8 +35,8 @@ public class SettlementListResponse {
                 .caseTitle(cases.getTitle())
                 .settlementId(settlement != null ? settlement.getId() : null)
                 .paymentStatus(settlement != null ? settlement.getPaymentStatus() : null)
-                .total(settlement != null ? settlement.getTotal() : null)
-                .dueDate(settlement != null ? settlement.getDueDate() : null)
+                .agreementAmount(settlement != null ? settlement.getAgreementAmount() : null)
+                .paymentDueDate(settlement != null ? settlement.getPaymentDueDate() : null)
                 .build();
     }
 }

--- a/src/main/java/com/haeil/be/settlement/dto/response/SettlementListResponse.java
+++ b/src/main/java/com/haeil/be/settlement/dto/response/SettlementListResponse.java
@@ -1,0 +1,42 @@
+package com.haeil.be.settlement.dto.response;
+
+import com.haeil.be.cases.domain.Cases;
+import com.haeil.be.settlement.domain.Settlement;
+import com.haeil.be.settlement.domain.type.PaymentStatus;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SettlementListResponse {
+
+    private Long caseId;
+    private String caseTitle;
+    private Long settlementId;
+    private PaymentStatus paymentStatus;
+    private BigDecimal total;
+    private LocalDate dueDate;
+
+    /**
+     * Repository에서 반환된 Object[] 결과를 SettlementListResponse로 변환합니다. Object[]의 첫 번째 요소는 Cases, 두 번째
+     * 요소는 Settlement (또는 null)입니다.
+     *
+     * @param result Object[] 배열 [Cases, Settlement]
+     * @return SettlementListResponse
+     */
+    public static SettlementListResponse from(Object[] result) {
+        Cases cases = (Cases) result[0];
+        Settlement settlement = (Settlement) result[1];
+
+        return SettlementListResponse.builder()
+                .caseId(cases.getId())
+                .caseTitle(cases.getTitle())
+                .settlementId(settlement != null ? settlement.getId() : null)
+                .paymentStatus(settlement != null ? settlement.getPaymentStatus() : null)
+                .total(settlement != null ? settlement.getTotal() : null)
+                .dueDate(settlement != null ? settlement.getDueDate() : null)
+                .build();
+    }
+}

--- a/src/main/java/com/haeil/be/settlement/dto/response/SettlementResponse.java
+++ b/src/main/java/com/haeil/be/settlement/dto/response/SettlementResponse.java
@@ -38,10 +38,7 @@ public class SettlementResponse {
                 .settlementDate(settlement.getSettlementDate())
                 .dueDate(settlement.getDueDate())
                 .note(settlement.getNote())
-                .caseId(
-                        settlement.getRelatedCase() != null
-                                ? settlement.getRelatedCase().getId()
-                                : null)
+                .caseId(settlement.getCases() != null ? settlement.getCases().getId() : null)
                 .createdDate(settlement.getCreatedDate())
                 .modifiedDate(settlement.getModifiedDate())
                 .build();

--- a/src/main/java/com/haeil/be/settlement/dto/response/SettlementResponse.java
+++ b/src/main/java/com/haeil/be/settlement/dto/response/SettlementResponse.java
@@ -2,6 +2,7 @@ package com.haeil.be.settlement.dto.response;
 
 import com.haeil.be.settlement.domain.Settlement;
 import com.haeil.be.settlement.domain.type.PaymentStatus;
+import com.haeil.be.settlement.domain.type.SettlementStatus;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -14,13 +15,14 @@ public class SettlementResponse {
 
     private Long id;
     private PaymentStatus paymentStatus;
-    private BigDecimal lawyerFee;
-    private BigDecimal total;
+    private SettlementStatus settlementStatus;
+    private BigDecimal attorneyFee;
+    private BigDecimal agreementAmount;
     private BigDecimal expenses;
     private Boolean isVatIncluded;
     private BigDecimal clientReceivable;
     private LocalDate settlementDate;
-    private LocalDate dueDate;
+    private LocalDate paymentDueDate;
     private String note;
     private Long caseId;
     private LocalDateTime createdDate;
@@ -30,13 +32,14 @@ public class SettlementResponse {
         return SettlementResponse.builder()
                 .id(settlement.getId())
                 .paymentStatus(settlement.getPaymentStatus())
-                .lawyerFee(settlement.getLawyerFee())
-                .total(settlement.getTotal())
+                .settlementStatus(settlement.getSettlementStatus())
+                .attorneyFee(settlement.getAttorneyFee())
+                .agreementAmount(settlement.getAgreementAmount())
                 .expenses(settlement.getExpenses())
                 .isVatIncluded(settlement.getIsVatIncluded())
                 .clientReceivable(settlement.getClientReceivable())
                 .settlementDate(settlement.getSettlementDate())
-                .dueDate(settlement.getDueDate())
+                .paymentDueDate(settlement.getPaymentDueDate())
                 .note(settlement.getNote())
                 .caseId(settlement.getCases() != null ? settlement.getCases().getId() : null)
                 .createdDate(settlement.getCreatedDate())

--- a/src/main/java/com/haeil/be/settlement/dto/response/SettlementResponse.java
+++ b/src/main/java/com/haeil/be/settlement/dto/response/SettlementResponse.java
@@ -1,0 +1,49 @@
+package com.haeil.be.settlement.dto.response;
+
+import com.haeil.be.settlement.domain.Settlement;
+import com.haeil.be.settlement.domain.type.PaymentStatus;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SettlementResponse {
+
+    private Long id;
+    private PaymentStatus paymentStatus;
+    private BigDecimal lawyerFee;
+    private BigDecimal total;
+    private BigDecimal expenses;
+    private Boolean isVatIncluded;
+    private BigDecimal clientReceivable;
+    private LocalDate settlementDate;
+    private LocalDate dueDate;
+    private String note;
+    private Long caseId;
+    private LocalDateTime createdDate;
+    private LocalDateTime modifiedDate;
+
+    public static SettlementResponse from(Settlement settlement) {
+        return SettlementResponse.builder()
+                .id(settlement.getId())
+                .paymentStatus(settlement.getPaymentStatus())
+                .lawyerFee(settlement.getLawyerFee())
+                .total(settlement.getTotal())
+                .expenses(settlement.getExpenses())
+                .isVatIncluded(settlement.getIsVatIncluded())
+                .clientReceivable(settlement.getClientReceivable())
+                .settlementDate(settlement.getSettlementDate())
+                .dueDate(settlement.getDueDate())
+                .note(settlement.getNote())
+                .caseId(
+                        settlement.getRelatedCase() != null
+                                ? settlement.getRelatedCase().getId()
+                                : null)
+                .createdDate(settlement.getCreatedDate())
+                .modifiedDate(settlement.getModifiedDate())
+                .build();
+    }
+}

--- a/src/main/java/com/haeil/be/settlement/exception/SettlementException.java
+++ b/src/main/java/com/haeil/be/settlement/exception/SettlementException.java
@@ -1,0 +1,11 @@
+package com.haeil.be.settlement.exception;
+
+import com.haeil.be.global.exception.errorcode.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class SettlementException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/haeil/be/settlement/exception/errorcode/SettlementErrorCode.java
+++ b/src/main/java/com/haeil/be/settlement/exception/errorcode/SettlementErrorCode.java
@@ -1,0 +1,18 @@
+package com.haeil.be.settlement.exception.errorcode;
+
+import com.haeil.be.global.exception.errorcode.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SettlementErrorCode implements ErrorCode {
+    SETTLEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "정산 정보를 찾을 수 없습니다."),
+    INVALID_SETTLEMENT_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 정산 상태입니다."),
+    INVALID_CALCULATION(HttpStatus.BAD_REQUEST, "정산 금액 계산이 올바르지 않습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/haeil/be/settlement/repository/SettlementRepository.java
+++ b/src/main/java/com/haeil/be/settlement/repository/SettlementRepository.java
@@ -1,0 +1,24 @@
+package com.haeil.be.settlement.repository;
+
+import com.haeil.be.cases.domain.type.CaseStatus;
+import com.haeil.be.settlement.domain.Settlement;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface SettlementRepository extends JpaRepository<Settlement, Long> {
+
+    /**
+     * 완료된 사건 기준으로 정산서 리스트를 조회합니다. 정산서가 없는 사건도 포함하여 반환합니다.
+     *
+     * @param caseStatus 사건 상태 (예: CaseStatus.COMPLETED)
+     * @return 사건 정보와 정산서 정보를 포함한 리스트 (정산서가 없으면 null)
+     */
+    @Query(
+            "SELECT c, s FROM com.haeil.be.cases.domain.Cases c "
+                    + "LEFT JOIN com.haeil.be.settlement.domain.Settlement s ON s.relatedCase.id = c.id "
+                    + "WHERE c.caseStatus = :caseStatus "
+                    + "ORDER BY c.createdDate DESC")
+    List<Object[]> findSettlementsByCaseStatus(@Param("caseStatus") CaseStatus caseStatus);
+}

--- a/src/main/java/com/haeil/be/settlement/repository/SettlementRepository.java
+++ b/src/main/java/com/haeil/be/settlement/repository/SettlementRepository.java
@@ -10,15 +10,15 @@ import org.springframework.data.repository.query.Param;
 public interface SettlementRepository extends JpaRepository<Settlement, Long> {
 
     /**
-     * 완료된 사건 기준으로 정산서 리스트를 조회합니다. 정산서가 없는 사건도 포함하여 반환합니다.
+     * 진행중 또는 완료된 사건 기준으로 정산서 리스트를 조회합니다. 정산서가 없는 사건도 포함하여 반환합니다.
      *
-     * @param caseStatus 사건 상태 (예: CaseStatus.COMPLETED)
      * @return 사건 정보와 정산서 정보를 포함한 리스트 (정산서가 없으면 null)
      */
     @Query(
             "SELECT c, s FROM com.haeil.be.cases.domain.Cases c "
                     + "LEFT JOIN com.haeil.be.settlement.domain.Settlement s ON s.cases.id = c.id "
-                    + "WHERE c.caseStatus = :caseStatus "
+                    + "WHERE c.caseStatus IN :caseStatuses "
                     + "ORDER BY c.createdDate DESC")
-    List<Object[]> findSettlementsByCaseStatus(@Param("caseStatus") CaseStatus caseStatus);
+    List<Object[]> findSettlementsByCaseStatuses(
+            @Param("caseStatuses") List<CaseStatus> caseStatuses);
 }

--- a/src/main/java/com/haeil/be/settlement/repository/SettlementRepository.java
+++ b/src/main/java/com/haeil/be/settlement/repository/SettlementRepository.java
@@ -17,7 +17,7 @@ public interface SettlementRepository extends JpaRepository<Settlement, Long> {
      */
     @Query(
             "SELECT c, s FROM com.haeil.be.cases.domain.Cases c "
-                    + "LEFT JOIN com.haeil.be.settlement.domain.Settlement s ON s.relatedCase.id = c.id "
+                    + "LEFT JOIN com.haeil.be.settlement.domain.Settlement s ON s.cases.id = c.id "
                     + "WHERE c.caseStatus = :caseStatus "
                     + "ORDER BY c.createdDate DESC")
     List<Object[]> findSettlementsByCaseStatus(@Param("caseStatus") CaseStatus caseStatus);

--- a/src/main/java/com/haeil/be/settlement/service/SettlementService.java
+++ b/src/main/java/com/haeil/be/settlement/service/SettlementService.java
@@ -48,7 +48,7 @@ public class SettlementService {
      */
     @Transactional
     public SettlementResponse createSettlement(CreateSettlementRequest request) {
-        Cases relatedCase =
+        Cases cases =
                 casesRepository
                         .findById(request.getCaseId())
                         .orElseThrow(
@@ -70,7 +70,7 @@ public class SettlementService {
                         .settlementDate(request.getSettlementDate())
                         .dueDate(request.getDueDate())
                         .note(request.getNote())
-                        .relatedCase(relatedCase)
+                        .cases(cases)
                         .build();
 
         // clientReceivable 자동 계산

--- a/src/main/java/com/haeil/be/settlement/service/SettlementService.java
+++ b/src/main/java/com/haeil/be/settlement/service/SettlementService.java
@@ -66,12 +66,15 @@ public class SettlementService {
                                 request.getIsVatIncluded() != null
                                         ? request.getIsVatIncluded()
                                         : false)
-                        .clientReceivable(request.getClientReceivable())
+                        .clientReceivable(null) // 자동 계산됨
                         .settlementDate(request.getSettlementDate())
                         .dueDate(request.getDueDate())
                         .note(request.getNote())
                         .relatedCase(relatedCase)
                         .build();
+
+        // clientReceivable 자동 계산
+        settlement.recalculateClientReceivable();
 
         Settlement savedSettlement = settlementRepository.save(settlement);
         return SettlementResponse.from(savedSettlement);

--- a/src/main/java/com/haeil/be/settlement/service/SettlementService.java
+++ b/src/main/java/com/haeil/be/settlement/service/SettlementService.java
@@ -117,7 +117,6 @@ public class SettlementService {
                                                 SettlementErrorCode.SETTLEMENT_NOT_FOUND));
 
         settlement.update(
-                request.getPaymentStatus(),
                 request.getLawyerFee(),
                 request.getTotal(),
                 request.getExpenses(),
@@ -126,6 +125,30 @@ public class SettlementService {
                 request.getSettlementDate(),
                 request.getDueDate(),
                 request.getNote());
+
+        Settlement updatedSettlement = settlementRepository.save(settlement);
+        return SettlementResponse.from(updatedSettlement);
+    }
+
+    /**
+     * 정산 상태 변경 정산서의 결제 상태를 변경합니다.
+     *
+     * @param id 정산서 ID
+     * @param paymentStatus 변경할 결제 상태
+     * @return 수정된 정산서 정보
+     * @throws SettlementException 정산서가 존재하지 않는 경우
+     */
+    @Transactional
+    public SettlementResponse updatePaymentStatus(Long id, PaymentStatus paymentStatus) {
+        Settlement settlement =
+                settlementRepository
+                        .findById(id)
+                        .orElseThrow(
+                                () ->
+                                        new SettlementException(
+                                                SettlementErrorCode.SETTLEMENT_NOT_FOUND));
+
+        settlement.changePaymentStatus(paymentStatus);
 
         Settlement updatedSettlement = settlementRepository.save(settlement);
         return SettlementResponse.from(updatedSettlement);

--- a/src/main/java/com/haeil/be/settlement/service/SettlementService.java
+++ b/src/main/java/com/haeil/be/settlement/service/SettlementService.java
@@ -1,0 +1,131 @@
+package com.haeil.be.settlement.service;
+
+import com.haeil.be.cases.domain.Cases;
+import com.haeil.be.cases.domain.type.CaseStatus;
+import com.haeil.be.cases.repository.CasesRepository;
+import com.haeil.be.settlement.domain.Settlement;
+import com.haeil.be.settlement.domain.type.PaymentStatus;
+import com.haeil.be.settlement.dto.request.CreateSettlementRequest;
+import com.haeil.be.settlement.dto.request.UpdateSettlementRequest;
+import com.haeil.be.settlement.dto.response.SettlementListResponse;
+import com.haeil.be.settlement.dto.response.SettlementResponse;
+import com.haeil.be.settlement.exception.SettlementException;
+import com.haeil.be.settlement.exception.errorcode.SettlementErrorCode;
+import com.haeil.be.settlement.repository.SettlementRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SettlementService {
+
+    private final SettlementRepository settlementRepository;
+    private final CasesRepository casesRepository;
+
+    /**
+     * 정산 관리 리스트 조회 완료된 사건 기준으로 정산서 리스트를 조회합니다. 정산서가 없는 사건도 포함하여 반환합니다. 프론트에서 settlementId가 null이면
+     * "정산서 작성" 버튼을 활성화할 수 있습니다.
+     *
+     * @return 정산 리스트 정보 (사건 정보 + 정산서 정보, 정산서가 없으면 null)
+     */
+    @Transactional(readOnly = true)
+    public List<SettlementListResponse> getSettlements() {
+        List<Object[]> results =
+                settlementRepository.findSettlementsByCaseStatus(CaseStatus.COMPLETED);
+
+        return results.stream().map(SettlementListResponse::from).collect(Collectors.toList());
+    }
+
+    /**
+     * 정산서 작성 사건 ID 기준으로 관련 사건을 조회한 후 Settlement 엔티티를 생성합니다. 초기 paymentStatus는 입금 대기(PENDING)로
+     * 설정됩니다.
+     *
+     * @param request 정산서 생성 요청 DTO
+     * @return 생성된 정산서 정보
+     */
+    @Transactional
+    public SettlementResponse createSettlement(CreateSettlementRequest request) {
+        Cases relatedCase =
+                casesRepository
+                        .findById(request.getCaseId())
+                        .orElseThrow(
+                                () ->
+                                        new SettlementException(
+                                                SettlementErrorCode.SETTLEMENT_NOT_FOUND));
+
+        Settlement settlement =
+                Settlement.builder()
+                        .paymentStatus(PaymentStatus.PENDING) // 초기값: 입금 대기
+                        .lawyerFee(request.getLawyerFee())
+                        .total(request.getTotal())
+                        .expenses(request.getExpenses())
+                        .isVatIncluded(
+                                request.getIsVatIncluded() != null
+                                        ? request.getIsVatIncluded()
+                                        : false)
+                        .clientReceivable(request.getClientReceivable())
+                        .settlementDate(request.getSettlementDate())
+                        .dueDate(request.getDueDate())
+                        .note(request.getNote())
+                        .relatedCase(relatedCase)
+                        .build();
+
+        Settlement savedSettlement = settlementRepository.save(settlement);
+        return SettlementResponse.from(savedSettlement);
+    }
+
+    /**
+     * 정산서 상세 조회 정산서 ID로 상세 정보를 조회합니다.
+     *
+     * @param id 정산서 ID
+     * @return 정산서 상세 정보
+     * @throws SettlementException 정산서가 존재하지 않는 경우
+     */
+    @Transactional(readOnly = true)
+    public SettlementResponse getSettlement(Long id) {
+        Settlement settlement =
+                settlementRepository
+                        .findById(id)
+                        .orElseThrow(
+                                () ->
+                                        new SettlementException(
+                                                SettlementErrorCode.SETTLEMENT_NOT_FOUND));
+        return SettlementResponse.from(settlement);
+    }
+
+    /**
+     * 정산서 수정 수정 가능한 필드만 업데이트합니다.
+     *
+     * @param id 정산서 ID
+     * @param request 정산서 수정 요청 DTO
+     * @return 수정된 정산서 정보
+     * @throws SettlementException 정산서가 존재하지 않는 경우
+     */
+    @Transactional
+    public SettlementResponse updateSettlement(Long id, UpdateSettlementRequest request) {
+        Settlement settlement =
+                settlementRepository
+                        .findById(id)
+                        .orElseThrow(
+                                () ->
+                                        new SettlementException(
+                                                SettlementErrorCode.SETTLEMENT_NOT_FOUND));
+
+        settlement.update(
+                request.getPaymentStatus(),
+                request.getLawyerFee(),
+                request.getTotal(),
+                request.getExpenses(),
+                request.getIsVatIncluded(),
+                request.getClientReceivable(),
+                request.getSettlementDate(),
+                request.getDueDate(),
+                request.getNote());
+
+        Settlement updatedSettlement = settlementRepository.save(settlement);
+        return SettlementResponse.from(updatedSettlement);
+    }
+}

--- a/src/main/java/com/haeil/be/settlement/service/SettlementService.java
+++ b/src/main/java/com/haeil/be/settlement/service/SettlementService.java
@@ -2,6 +2,8 @@ package com.haeil.be.settlement.service;
 
 import com.haeil.be.cases.domain.Cases;
 import com.haeil.be.cases.domain.type.CaseStatus;
+import com.haeil.be.cases.exception.CasesException;
+import com.haeil.be.cases.exception.errorcode.CasesErrorCode;
 import com.haeil.be.cases.repository.CasesRepository;
 import com.haeil.be.settlement.domain.Settlement;
 import com.haeil.be.settlement.domain.type.PaymentStatus;
@@ -51,10 +53,7 @@ public class SettlementService {
         Cases cases =
                 casesRepository
                         .findById(request.getCaseId())
-                        .orElseThrow(
-                                () ->
-                                        new SettlementException(
-                                                SettlementErrorCode.SETTLEMENT_NOT_FOUND));
+                        .orElseThrow(() -> new CasesException(CasesErrorCode.CASE_NOT_FOUND));
 
         Settlement settlement =
                 Settlement.builder()

--- a/src/main/java/com/haeil/be/settlement/service/SettlementService.java
+++ b/src/main/java/com/haeil/be/settlement/service/SettlementService.java
@@ -15,6 +15,7 @@ import com.haeil.be.settlement.dto.response.SettlementResponse;
 import com.haeil.be.settlement.exception.SettlementException;
 import com.haeil.be.settlement.exception.errorcode.SettlementErrorCode;
 import com.haeil.be.settlement.repository.SettlementRepository;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -29,15 +30,16 @@ public class SettlementService {
     private final CasesRepository casesRepository;
 
     /**
-     * 정산 관리 리스트 조회 완료된 사건 기준으로 정산서 리스트를 조회합니다. 정산서가 없는 사건도 포함하여 반환합니다. 프론트에서 settlementId가 null이면
-     * "정산서 작성" 버튼을 활성화할 수 있습니다.
+     * 정산 관리 리스트 조회 진행중 또는 완료된 사건 기준으로 정산서 리스트를 조회합니다. 정산서가 없는 사건도 포함하여 반환합니다. 프론트에서 settlementId가
+     * null이면 "정산서 작성" 버튼을 활성화할 수 있습니다.
      *
      * @return 정산 리스트 정보 (사건 정보 + 정산서 정보, 정산서가 없으면 null)
      */
     @Transactional(readOnly = true)
     public List<SettlementListResponse> getSettlements() {
         List<Object[]> results =
-                settlementRepository.findSettlementsByCaseStatus(CaseStatus.COMPLETED);
+                settlementRepository.findSettlementsByCaseStatuses(
+                        Arrays.asList(CaseStatus.IN_PROGRESS, CaseStatus.COMPLETED));
 
         return results.stream().map(SettlementListResponse::from).collect(Collectors.toList());
     }
@@ -126,7 +128,6 @@ public class SettlementService {
                 request.getAgreementAmount(),
                 request.getExpenses(),
                 request.getIsVatIncluded(),
-                request.getClientReceivable(),
                 request.getSettlementDate(),
                 request.getPaymentDueDate(),
                 request.getNote());


### PR DESCRIPTION
## 🪺 개요 
<img width="605" height="221" alt="image" src="https://github.com/user-attachments/assets/f9442b4f-736b-47ee-bbab-616dbb1da59d" />

정산 관련 API 4가지를 개발하였습니다.

## 💻 작업 사항 
1. 정산 목록 조회 API 구현
- 사건 중 완료된 사건만 조회하도록 조건을 적용하였습니다.
- 사건(case) 테이블과 정산(settlement) 테이블을 LEFT JOIN하여, 정산 정보가 없는 사건도 목록에 포함되도록 설계하였습니다.
- JOIN 이후 정산 데이터가 존재하지 않을 경우, 프론트 구분을 위해 정산 정보 필드는 null로 반환되도록 처리하였습니다.

2. 정산 상세 조회 API 구현
- 정산 ID 기준으로 단일 정산 정보를 반환하도록 설계했습니다.
- 정산 정보가 존재하지 않을 경우를 위해 예외 처리를 추가하였습니다.

3. 정산 등록 API 구현
- 신규 정산 데이터를 생성하여 저장합니다.
- VAT 포함 여부, 변호사 보수, 총 청구액 등 금액 필드를 검증합니다.

4. 정산 수정 API 구현
- 정산서를 수정할 수 있는 API를 구현했습니다.

##  변경사항 추가(11/19)
- CreateSettlementRequest에서 paymentStatus 제거 및 CaseErrorCode 사용
- 정산서 결제 상태 변경 API 구현, UpdatePaymentStatusRequest DTO 추가
- 정산서 상태 관리(settlement_status) 추가, NONE(미작성)→DRAFT(작성중)→FINAL(작성완료) 자동 전환 로직 구현
- 정산 필드명 개선 (attorneyFee, agreementAmount 등)
- 정산 목록 조회 범위를 "진행중" 사건까지 확장
- 의뢰인 수령액(clientReceivable) 요청 제거 후 내부 자동 계산

> replit 기준으로 구현하였고, 수정 부분도 필요할 거 같아서 추가하였습니다.

## 🌱 Issue Number
- #9 

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요 ?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요 ?
- [x] 테스트는 잘 통과했나요 ?
- [x] 빌드에 성공했나요 ?
- [x] 본인을 Assign 해주세요.
- [x] 리뷰할 팀원들을 Request 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙏 To Reviewers
>  API 기능 별로 Commit 하지 않았고, 연관된 File 별로 Commit 했습니다. 다음부턴 기능 별로 구현할 때마다 Commit 하겠습니다!!
