### PR TITLE
[FEAT] 사건 관련 API구현 2

### DIFF
--- a/src/main/java/com/haeil/be/cases/controller/CasesController.java
+++ b/src/main/java/com/haeil/be/cases/controller/CasesController.java
@@ -106,7 +106,7 @@ public class CasesController {
 
     // 소장 조회
     @Operation(summary = "소장 조회", description = "작성된 소장을 조회합니다.")
-    @GetMapping("/ongoing/{caseId}/petition")
+    @GetMapping("/ongoing/{caseId}/petition/{id}")
     public ApiResponse<Object> getPetition(
             @PathVariable Long caseId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -115,7 +115,7 @@ public class CasesController {
 
     // 소장 수정
     @Operation(summary = "소장 수정", description = "작성된 소장을 수정합니다.")
-    @PatchMapping("/ongoing/{caseId}/petition")
+    @PatchMapping("/ongoing/{caseId}/petition/{id}")
     public ApiResponse<Object> updatePetition(
             @PathVariable Long caseId,
             @RequestBody PetitionRequest request,

--- a/src/main/java/com/haeil/be/cases/controller/CasesController.java
+++ b/src/main/java/com/haeil/be/cases/controller/CasesController.java
@@ -1,7 +1,9 @@
 package com.haeil.be.cases.controller;
 
 import com.haeil.be.cases.dto.request.AssignAttorneyRequest;
+import com.haeil.be.cases.dto.request.CaseNumberRequest;
 import com.haeil.be.cases.dto.request.DecisionRequest;
+import com.haeil.be.cases.dto.request.PetitionRequest;
 import com.haeil.be.cases.service.CasesService;
 import com.haeil.be.global.response.ApiResponse;
 import com.haeil.be.user.service.CustomUserDetails;
@@ -90,4 +92,48 @@ public class CasesController {
             @PathVariable Long caseId, @AuthenticationPrincipal CustomUserDetails userDetails) {
         return ApiResponse.from(casesService.getOngoingCaseDetail(caseId, userDetails.getId()));
     }
+
+    // 소장 작성
+    @Operation(summary = "소장 작성", description = "진행 중인 사건에 대한 소장을 작성합니다.")
+    @PostMapping("/ongoing/{caseId}/petition")
+    public ApiResponse<Object> createPetition(
+            @PathVariable Long caseId,
+            @RequestBody PetitionRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        casesService.createPetition(caseId, request, userDetails.getId());
+        return ApiResponse.EMPTY_RESPONSE;
+    }
+
+    // 소장 조회
+    @Operation(summary = "소장 조회", description = "작성된 소장을 조회합니다.")
+    @GetMapping("/ongoing/{caseId}/petition")
+    public ApiResponse<Object> getPetition(
+            @PathVariable Long caseId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ApiResponse.from(casesService.getPetition(caseId, userDetails.getId()));
+    }
+
+    // 소장 수정
+    @Operation(summary = "소장 수정", description = "작성된 소장을 수정합니다.")
+    @PatchMapping("/ongoing/{caseId}/petition")
+    public ApiResponse<Object> updatePetition(
+            @PathVariable Long caseId,
+            @RequestBody PetitionRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        casesService.updatePetition(caseId, request, userDetails.getId());
+        return ApiResponse.EMPTY_RESPONSE;
+    }
+
+    //법원에서 할당된 사건번호 추가
+    @Operation(summary = "사건번호 등록", description = "정식 사건 번호를 추가합니다")
+    @PatchMapping("/ongoing/{caseId}/caseNumber")
+    public ApiResponse<Object> updateCaseNumber(
+            @PathVariable Long caseId,
+            @RequestBody CaseNumberRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        casesService.updateCaseNumber(caseId, request.caseNumber(), userDetails.getId());
+        return ApiResponse.EMPTY_RESPONSE;
+    }
+
 }

--- a/src/main/java/com/haeil/be/cases/controller/CasesController.java
+++ b/src/main/java/com/haeil/be/cases/controller/CasesController.java
@@ -1,6 +1,7 @@
 package com.haeil.be.cases.controller;
 
 import com.haeil.be.cases.dto.request.AssignAttorneyRequest;
+import com.haeil.be.cases.dto.request.CaseDocumentRequest;
 import com.haeil.be.cases.dto.request.CaseNumberRequest;
 import com.haeil.be.cases.dto.request.DecisionRequest;
 import com.haeil.be.cases.dto.request.PetitionRequest;
@@ -11,13 +12,16 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Cases", description = "사건 관련 API")
 @RequestMapping("/api/v1/cases")
@@ -106,7 +110,7 @@ public class CasesController {
 
     // 소장 조회
     @Operation(summary = "소장 조회", description = "작성된 소장을 조회합니다.")
-    @GetMapping("/ongoing/{caseId}/petition/{id}")
+    @GetMapping("/ongoing/{caseId}/petition")
     public ApiResponse<Object> getPetition(
             @PathVariable Long caseId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -115,7 +119,7 @@ public class CasesController {
 
     // 소장 수정
     @Operation(summary = "소장 수정", description = "작성된 소장을 수정합니다.")
-    @PatchMapping("/ongoing/{caseId}/petition/{id}")
+    @PatchMapping("/ongoing/{caseId}/petition")
     public ApiResponse<Object> updatePetition(
             @PathVariable Long caseId,
             @RequestBody PetitionRequest request,
@@ -133,6 +137,38 @@ public class CasesController {
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         casesService.updateCaseNumber(caseId, request.caseNumber(), userDetails.getId());
+        return ApiResponse.EMPTY_RESPONSE;
+    }
+
+    // 소송문서 업로드
+    @Operation(summary = "소송문서 업로드", description = "진행 중인 사건에 소송문서를 업로드합니다.")
+    @PostMapping("/ongoing/{caseId}/documents")
+    public ApiResponse<Object> uploadCaseDocument(
+            @PathVariable Long caseId,
+            @RequestPart("file") MultipartFile file,
+            @RequestPart("request") CaseDocumentRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) throws java.io.IOException {
+        return ApiResponse.from(
+                casesService.uploadCaseDocument(caseId, file, request, userDetails.getId()));
+    }
+
+    // 소송문서 목록 조회
+    @Operation(summary = "소송문서 목록 조회", description = "업로드된 소송문서 목록을 조회합니다.")
+    @GetMapping("/ongoing/{caseId}/documents")
+    public ApiResponse<Object> getCaseDocuments(
+            @PathVariable Long caseId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ApiResponse.from(casesService.getCaseDocuments(caseId, userDetails.getId()));
+    }
+
+    // 소송문서 삭제
+    @Operation(summary = "소송문서 삭제", description = "업로드된 소송문서를 삭제합니다.")
+    @DeleteMapping("/ongoing/{caseId}/documents/{documentId}")
+    public ApiResponse<Object> deleteCaseDocument(
+            @PathVariable Long caseId,
+            @PathVariable Long documentId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) throws java.io.IOException {
+        casesService.deleteCaseDocument(caseId, documentId, userDetails.getId());
         return ApiResponse.EMPTY_RESPONSE;
     }
 

--- a/src/main/java/com/haeil/be/cases/controller/CasesController.java
+++ b/src/main/java/com/haeil/be/cases/controller/CasesController.java
@@ -181,4 +181,20 @@ public class CasesController {
         casesService.completeCase(caseId, userDetails.getId());
         return ApiResponse.EMPTY_RESPONSE;
     }
+
+    // 완료된 사건 목록조회
+    @Operation(summary = "완료된 사건 목록 조회", description = "담당 변호사가 완료한 사건들을 조회합니다.")
+    @GetMapping("/completed")
+    public ApiResponse<Object> getCompletedCases(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ApiResponse.from(casesService.getCompletedCases(userDetails.getId()));
+    }
+
+    // 완료된 사건 상세보기
+    @Operation(summary = "완료된 사건 상세보기", description = "완료된 사건의 상세 정보를 조회합니다.")
+    @GetMapping("/completed/{caseId}")
+    public ApiResponse<Object> getCompletedCaseDetail(
+            @PathVariable Long caseId, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ApiResponse.from(casesService.getCompletedCaseDetail(caseId, userDetails.getId()));
+    }
 }

--- a/src/main/java/com/haeil/be/cases/controller/CasesController.java
+++ b/src/main/java/com/haeil/be/cases/controller/CasesController.java
@@ -171,5 +171,14 @@ public class CasesController {
         casesService.deleteCaseDocument(caseId, documentId, userDetails.getId());
         return ApiResponse.EMPTY_RESPONSE;
     }
+    //사건 완료처리
+    @Operation(summary = "사건 완료 처리", description = "진행 중 사건을 완료된 사건 상태로 변경합니다.")
+    @PatchMapping("/ongoing/{caseId}/complete")
+    public ApiResponse<Object> completeCase(
+            @PathVariable Long caseId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
+        casesService.completeCase(caseId, userDetails.getId());
+        return ApiResponse.EMPTY_RESPONSE;
+    }
 }

--- a/src/main/java/com/haeil/be/cases/domain/CaseDocument.java
+++ b/src/main/java/com/haeil/be/cases/domain/CaseDocument.java
@@ -1,8 +1,10 @@
 package com.haeil.be.cases.domain;
 
 import com.haeil.be.cases.domain.type.DocumentType;
+import com.haeil.be.file.domain.FileEntity;
 import com.haeil.be.global.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,4 +25,23 @@ public class CaseDocument extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "case_id")
     private Cases cases;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "file_id")
+    private FileEntity file;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Builder
+    public CaseDocument(
+            DocumentType documentType,
+            Cases cases,
+            FileEntity file,
+            String description) {
+        this.documentType = documentType;
+        this.cases = cases;
+        this.file = file;
+        this.description = description;
+    }
 }

--- a/src/main/java/com/haeil/be/cases/domain/Cases.java
+++ b/src/main/java/com/haeil/be/cases/domain/Cases.java
@@ -79,6 +79,13 @@ public class Cases extends BaseEntity {
             orphanRemoval = true)
     private List<CaseEvent> caseEventList = new ArrayList<>();
 
+    @OneToOne(
+            mappedBy = "cases",
+            fetch = FetchType.LAZY,
+            cascade = CascadeType.ALL,
+            orphanRemoval = true)
+    private Petition petition;
+
     @Builder
     public Cases(
             String title,
@@ -115,5 +122,9 @@ public class Cases extends BaseEntity {
 
     public void updateStatus(CaseStatus caseStatus) {
         this.caseStatus = caseStatus;
+    }
+
+    public void updateCaseNumber(String caseNumber) {
+        this.caseNumber = caseNumber;
     }
 }

--- a/src/main/java/com/haeil/be/cases/domain/Petition.java
+++ b/src/main/java/com/haeil/be/cases/domain/Petition.java
@@ -1,0 +1,109 @@
+package com.haeil.be.cases.domain;
+
+import com.haeil.be.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "petition")
+@Entity
+@Getter
+@NoArgsConstructor
+public class Petition extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "case_id", unique = true)
+    private Cases cases;
+
+    // 청구 취지
+    @Column(name = "claim_amount")  //청구금액
+    private Long claimAmount;
+
+    @Column(name = "claim_content", columnDefinition = "TEXT") //청구내용
+    private String claimContent;
+
+    // 청구 원인
+    @Column(name = "accident_circumstances", columnDefinition = "TEXT")  //사고경위
+    private String accidentCircumstances;
+
+    @Column(name = "damage_items", columnDefinition = "TEXT")  //손해항목
+    private String damageItems;
+
+    @Column(name = "damage_calculation", columnDefinition = "TEXT")  //손해액상정
+    private String damageCalculation;
+
+    @Column(name = "liability_basis", columnDefinition = "TEXT")  //책임 인정 근거
+    private String liabilityBasis;
+
+    // 입증 방법
+    @Column(name = "proof_method", columnDefinition = "TEXT")
+    private String proofMethod;
+
+    // 첨부 서류
+    @Column(name = "attached_documents", columnDefinition = "TEXT")
+    private String attachedDocuments;
+
+    @Builder
+    public Petition(
+            Cases cases,
+            //청구취지
+            Long claimAmount,
+            String claimContent,
+            //청구원인
+            String accidentCircumstances,
+            String damageItems,
+            String damageCalculation,
+            String liabilityBasis,
+            //입증방법
+            String proofMethod,
+            //첨부 서류(당장은 string으로 처리했습니다)
+            String attachedDocuments) {
+        this.cases = cases;
+        this.claimAmount = claimAmount;
+        this.claimContent = claimContent;
+        this.accidentCircumstances = accidentCircumstances;
+        this.damageItems = damageItems;
+        this.damageCalculation = damageCalculation;
+        this.liabilityBasis = liabilityBasis;
+        this.proofMethod = proofMethod;
+        this.attachedDocuments = attachedDocuments;
+    }
+
+    public void updateClaimAmount(Long claimAmount) {
+        this.claimAmount = claimAmount;
+    }
+
+    public void updateClaimContent(String claimContent) {
+        this.claimContent = claimContent;
+    }
+
+    public void updateAccidentCircumstances(String accidentCircumstances) {
+        this.accidentCircumstances = accidentCircumstances;
+    }
+
+    public void updateDamageItems(String damageItems) {
+        this.damageItems = damageItems;
+    }
+
+    public void updateDamageCalculation(String damageCalculation) {
+        this.damageCalculation = damageCalculation;
+    }
+
+    public void updateLiabilityBasis(String liabilityBasis) {
+        this.liabilityBasis = liabilityBasis;
+    }
+
+    public void updateProofMethod(String proofMethod) {
+        this.proofMethod = proofMethod;
+    }
+
+    public void updateAttachedDocuments(String attachedDocuments) {
+        this.attachedDocuments = attachedDocuments;
+    }
+}
+

--- a/src/main/java/com/haeil/be/cases/dto/request/CaseDocumentRequest.java
+++ b/src/main/java/com/haeil/be/cases/dto/request/CaseDocumentRequest.java
@@ -1,0 +1,9 @@
+package com.haeil.be.cases.dto.request;
+
+import com.haeil.be.cases.domain.type.DocumentType;
+
+public record CaseDocumentRequest(
+        DocumentType documentType,
+        String description
+) {}
+

--- a/src/main/java/com/haeil/be/cases/dto/request/CaseNumberRequest.java
+++ b/src/main/java/com/haeil/be/cases/dto/request/CaseNumberRequest.java
@@ -1,0 +1,5 @@
+package com.haeil.be.cases.dto.request;
+
+public record CaseNumberRequest(
+        String caseNumber
+) {}

--- a/src/main/java/com/haeil/be/cases/dto/request/PetitionRequest.java
+++ b/src/main/java/com/haeil/be/cases/dto/request/PetitionRequest.java
@@ -1,0 +1,17 @@
+package com.haeil.be.cases.dto.request;
+
+public record PetitionRequest(
+        // 청구 취지
+        Long claimAmount,
+        String claimContent,
+        // 청구 원인
+        String accidentCircumstances,
+        String damageItems,
+        String damageCalculation,
+        String liabilityBasis,
+        // 입증 방법
+        String proofMethod,
+        // 첨부 서류(일단 string으로 처리했습니다!)
+        String attachedDocuments
+) {}
+

--- a/src/main/java/com/haeil/be/cases/dto/response/CaseDocumentResponse.java
+++ b/src/main/java/com/haeil/be/cases/dto/response/CaseDocumentResponse.java
@@ -1,0 +1,25 @@
+package com.haeil.be.cases.dto.response;
+
+import com.haeil.be.cases.domain.CaseDocument;
+import com.haeil.be.cases.domain.type.DocumentType;
+
+public record CaseDocumentResponse(
+        Long documentId,
+        DocumentType documentType,
+        String originalFilename,
+        String fileUrl,
+        Long fileSize,
+        String description
+) {
+    public static CaseDocumentResponse from(CaseDocument caseDocument) {
+        return new CaseDocumentResponse(
+                caseDocument.getId(),
+                caseDocument.getDocumentType(),
+                caseDocument.getFile() != null ? caseDocument.getFile().getOriginalFilename() : null,
+                caseDocument.getFile() != null ? caseDocument.getFile().getFileUrl() : null,
+                caseDocument.getFile() != null ? caseDocument.getFile().getFileSize() : null,
+                caseDocument.getDescription()
+        );
+    }
+}
+

--- a/src/main/java/com/haeil/be/cases/dto/response/CompletedCaseDetailResponse.java
+++ b/src/main/java/com/haeil/be/cases/dto/response/CompletedCaseDetailResponse.java
@@ -1,0 +1,34 @@
+package com.haeil.be.cases.dto.response;
+
+import com.haeil.be.cases.domain.Cases;
+import com.haeil.be.cases.domain.type.CaseStatus;
+import com.haeil.be.cases.domain.type.CaseType;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CompletedCaseDetailResponse(
+        // 사건정보
+        Long caseId,
+        String caseNumber,
+        String title,
+        String content,
+        CaseType caseType,
+        CaseStatus caseStatus,
+        LocalDateTime occurredDate,
+        String attorneyName,
+        // 사건진행결과
+        List<CaseEventResponse> caseProgress) {
+    public static CompletedCaseDetailResponse from(Cases cases) {
+        return new CompletedCaseDetailResponse(
+                cases.getId(),
+                cases.getCaseNumber(),
+                cases.getTitle(),
+                cases.getContent(),
+                cases.getCaseType(),
+                cases.getCaseStatus(),
+                cases.getOccurredDate(),
+                cases.getAttorney() != null ? cases.getAttorney().getName() : null,
+                cases.getCaseEventList().stream().map(CaseEventResponse::from).toList());
+    }
+}
+

--- a/src/main/java/com/haeil/be/cases/dto/response/CompletedCaseResponse.java
+++ b/src/main/java/com/haeil/be/cases/dto/response/CompletedCaseResponse.java
@@ -1,0 +1,25 @@
+package com.haeil.be.cases.dto.response;
+
+import com.haeil.be.cases.domain.Cases;
+import com.haeil.be.cases.domain.type.CaseStatus;
+import com.haeil.be.cases.domain.type.CaseType;
+import java.time.LocalDateTime;
+
+public record CompletedCaseResponse(
+        Long caseId,
+        String title,
+        CaseType caseType,
+        CaseStatus caseStatus,
+        LocalDateTime occurredDate,
+        String attorneyName) {
+    public static CompletedCaseResponse from(Cases cases) {
+        return new CompletedCaseResponse(
+                cases.getId(),
+                cases.getTitle(),
+                cases.getCaseType(),
+                cases.getCaseStatus(),
+                cases.getOccurredDate(),
+                cases.getAttorney() != null ? cases.getAttorney().getName() : null);
+    }
+}
+

--- a/src/main/java/com/haeil/be/cases/dto/response/PetitionResponse.java
+++ b/src/main/java/com/haeil/be/cases/dto/response/PetitionResponse.java
@@ -1,0 +1,34 @@
+package com.haeil.be.cases.dto.response;
+
+import com.haeil.be.cases.domain.Petition;
+
+public record PetitionResponse(
+        Long petitionId,
+        // 청구 취지
+        Long claimAmount,
+        String claimContent,
+        // 청구 원인
+        String accidentCircumstances,
+        String damageItems,
+        String damageCalculation,
+        String liabilityBasis,
+        // 입증 방법
+        String proofMethod,
+        // 첨부 서류
+        String attachedDocuments
+) {
+    public static PetitionResponse from(Petition petition) {
+        return new PetitionResponse(
+                petition.getId(),
+                petition.getClaimAmount(),
+                petition.getClaimContent(),
+                petition.getAccidentCircumstances(),
+                petition.getDamageItems(),
+                petition.getDamageCalculation(),
+                petition.getLiabilityBasis(),
+                petition.getProofMethod(),
+                petition.getAttachedDocuments()
+        );
+    }
+}
+

--- a/src/main/java/com/haeil/be/cases/exception/errorcode/CasesErrorCode.java
+++ b/src/main/java/com/haeil/be/cases/exception/errorcode/CasesErrorCode.java
@@ -16,10 +16,9 @@ public enum CasesErrorCode implements ErrorCode {
     PETITION_NOT_FOUND(HttpStatus.NOT_FOUND, "소장이 존재하지 않습니다."),
     CASE_DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "소송문서가 존재하지 않습니다."),
     FILE_REQUIRED(HttpStatus.BAD_REQUEST, "파일이 필요합니다."),
-    EMPTY_FILE(HttpStatus.BAD_REQUEST, "빈 파일은 업로드할 수 없습니다."),
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
     FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제에 실패했습니다."),
-    INVALID_DOCUMENT_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 문서 타입입니다.");
+    INVALID_CASE_STATUS(HttpStatus.BAD_REQUEST, "사건 상태가 유효하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/haeil/be/cases/exception/errorcode/CasesErrorCode.java
+++ b/src/main/java/com/haeil/be/cases/exception/errorcode/CasesErrorCode.java
@@ -11,7 +11,9 @@ public enum CasesErrorCode implements ErrorCode {
     CASE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사건이 존재하지 않습니다."),
     ALREADY_ASSIGNED_CASE(HttpStatus.BAD_REQUEST, "이미 배정된 사건입니다."),
     INVALID_ATTORNEY_ASSIGN(HttpStatus.BAD_REQUEST, "변호사 배정이 불가능한 상태입니다."),
-    ATTORNEY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 변호사입니다.");
+    ATTORNEY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 변호사입니다."),
+    PETITION_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 소장이 작성된 사건입니다."),
+    PETITION_NOT_FOUND(HttpStatus.NOT_FOUND, "소장이 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/haeil/be/cases/exception/errorcode/CasesErrorCode.java
+++ b/src/main/java/com/haeil/be/cases/exception/errorcode/CasesErrorCode.java
@@ -13,7 +13,13 @@ public enum CasesErrorCode implements ErrorCode {
     INVALID_ATTORNEY_ASSIGN(HttpStatus.BAD_REQUEST, "변호사 배정이 불가능한 상태입니다."),
     ATTORNEY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 변호사입니다."),
     PETITION_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 소장이 작성된 사건입니다."),
-    PETITION_NOT_FOUND(HttpStatus.NOT_FOUND, "소장이 존재하지 않습니다.");
+    PETITION_NOT_FOUND(HttpStatus.NOT_FOUND, "소장이 존재하지 않습니다."),
+    CASE_DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "소송문서가 존재하지 않습니다."),
+    FILE_REQUIRED(HttpStatus.BAD_REQUEST, "파일이 필요합니다."),
+    EMPTY_FILE(HttpStatus.BAD_REQUEST, "빈 파일은 업로드할 수 없습니다."),
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
+    FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제에 실패했습니다."),
+    INVALID_DOCUMENT_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 문서 타입입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/haeil/be/cases/repository/CaseDocumentRepository.java
+++ b/src/main/java/com/haeil/be/cases/repository/CaseDocumentRepository.java
@@ -1,0 +1,10 @@
+package com.haeil.be.cases.repository;
+
+import com.haeil.be.cases.domain.CaseDocument;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CaseDocumentRepository extends JpaRepository<CaseDocument, Long> {
+    List<CaseDocument> findByCasesId(Long caseId);
+}
+

--- a/src/main/java/com/haeil/be/cases/repository/PetitionRepository.java
+++ b/src/main/java/com/haeil/be/cases/repository/PetitionRepository.java
@@ -1,0 +1,8 @@
+package com.haeil.be.cases.repository;
+
+import com.haeil.be.cases.domain.Petition;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PetitionRepository extends JpaRepository<Petition, Long> {
+}
+

--- a/src/main/java/com/haeil/be/cases/service/CasesService.java
+++ b/src/main/java/com/haeil/be/cases/service/CasesService.java
@@ -2,12 +2,15 @@ package com.haeil.be.cases.service;
 
 import static com.haeil.be.cases.exception.errorcode.CasesErrorCode.CASE_NOT_FOUND;
 
+import com.haeil.be.cases.domain.CaseDocument;
 import com.haeil.be.cases.domain.Cases;
 import com.haeil.be.cases.domain.type.CaseStatus;
 import com.haeil.be.cases.domain.Petition;
 import com.haeil.be.cases.dto.request.AssignAttorneyRequest;
+import com.haeil.be.cases.dto.request.CaseDocumentRequest;
 import com.haeil.be.cases.dto.request.DecisionRequest;
 import com.haeil.be.cases.dto.request.PetitionRequest;
+import com.haeil.be.cases.dto.response.CaseDocumentResponse;
 import com.haeil.be.cases.dto.response.CaseInfoResponse;
 import com.haeil.be.cases.dto.response.PetitionResponse;
 import com.haeil.be.cases.dto.response.OngoingCaseDetailResponse;
@@ -18,15 +21,25 @@ import com.haeil.be.cases.dto.response.UnassignedCaseDetailResponse;
 import com.haeil.be.cases.dto.response.UnassignedCaseResponse;
 import com.haeil.be.cases.exception.CasesException;
 import com.haeil.be.cases.exception.errorcode.CasesErrorCode;
+import com.haeil.be.cases.repository.CaseDocumentRepository;
 import com.haeil.be.cases.repository.CasesRepository;
 import com.haeil.be.cases.repository.PetitionRepository;
 import com.haeil.be.consultation.domain.Consultation;
+import com.haeil.be.file.domain.FileEntity;
+import com.haeil.be.file.repository.FileRepository;
+import com.haeil.be.file.service.FileService;
 import com.haeil.be.user.domain.User;
 import com.haeil.be.user.repository.UserRepository;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +47,9 @@ public class CasesService {
 
     private final CasesRepository casesRepository;
     private final PetitionRepository petitionRepository;
+    private final CaseDocumentRepository caseDocumentRepository;
+    private final FileService fileService;
+    private final FileRepository fileRepository;
 
     @Transactional
     public Cases createCaseFromConsultation(Consultation consultation) {
@@ -322,6 +338,107 @@ public class CasesService {
 
         // 사건번호 업데이트
         foundCase.updateCaseNumber(caseNumber);
+    }
+
+    // 소송문서 업로드
+    @Transactional
+    public CaseDocumentResponse uploadCaseDocument(
+            Long caseId, MultipartFile file, CaseDocumentRequest request, Long userId) throws IOException {
+        Cases foundCase = getCasesOrThrow(caseId);
+
+        if (foundCase.getCaseStatus() != CaseStatus.IN_PROGRESS) {
+            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+        }
+
+        // 변호사는 본인 담당 사건만 소송문서 업로드 가능
+        if (foundCase.getAttorney() == null || !foundCase.getAttorney().getId().equals(userId)) {
+            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+        }
+
+        // 파일 검증
+        if (file == null || file.isEmpty()) {
+            throw new CasesException(CasesErrorCode.FILE_REQUIRED);
+        }
+
+        // 파일 업로드
+        FileEntity uploadedFile;
+        try {
+            uploadedFile = fileService.uploadFile(file);
+        } catch (IOException e) {
+            throw new CasesException(CasesErrorCode.FILE_UPLOAD_FAILED);
+        }
+
+        // 소송문서 생성
+        CaseDocument caseDocument = CaseDocument.builder()
+                .cases(foundCase)
+                .documentType(request.documentType())
+                .file(uploadedFile)
+                .description(request.description())
+                .build();
+
+        caseDocumentRepository.save(caseDocument);
+
+        return CaseDocumentResponse.from(caseDocument);
+    }
+
+    // 소송문서 목록 조회
+    @Transactional(readOnly = true)
+    public List<CaseDocumentResponse> getCaseDocuments(Long caseId, Long userId) {
+        Cases foundCase = getCasesOrThrow(caseId);
+
+        if (foundCase.getCaseStatus() != CaseStatus.IN_PROGRESS) {
+            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+        }
+
+        // 변호사는 본인 담당 사건만 소송문서 조회 가능
+        if (foundCase.getAttorney() == null || !foundCase.getAttorney().getId().equals(userId)) {
+            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+        }
+
+        List<CaseDocument> documents = caseDocumentRepository.findByCasesId(caseId);
+        return documents.stream()
+                .map(CaseDocumentResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    // 소송문서 삭제
+    @Transactional
+    public void deleteCaseDocument(Long caseId, Long documentId, Long userId) throws IOException {
+        Cases foundCase = getCasesOrThrow(caseId);
+
+        if (foundCase.getCaseStatus() != CaseStatus.IN_PROGRESS) {
+            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+        }
+
+        // 변호사는 본인 담당 사건만 소송문서 삭제 가능
+        if (foundCase.getAttorney() == null || !foundCase.getAttorney().getId().equals(userId)) {
+            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+        }
+
+        CaseDocument caseDocument = caseDocumentRepository.findById(documentId)
+                .orElseThrow(() -> new CasesException(CasesErrorCode.CASE_DOCUMENT_NOT_FOUND));
+
+        // 해당 사건의 문서인지 확인
+        if (!caseDocument.getCases().getId().equals(caseId)) {
+            throw new CasesException(CasesErrorCode.CASE_DOCUMENT_NOT_FOUND);
+        }
+
+        // 파일 삭제
+        FileEntity file = caseDocument.getFile();
+        if (file != null) {
+            try {
+                Path filePath = Paths.get(file.getFileUrl());
+                if (Files.exists(filePath)) {
+                    Files.delete(filePath);
+                }
+                fileRepository.delete(file);
+            } catch (IOException e) {
+                throw new CasesException(CasesErrorCode.FILE_DELETE_FAILED);
+            }
+        }
+
+        // 소송문서 삭제
+        caseDocumentRepository.delete(caseDocument);
     }
 
 }

--- a/src/main/java/com/haeil/be/cases/service/CasesService.java
+++ b/src/main/java/com/haeil/be/cases/service/CasesService.java
@@ -104,7 +104,7 @@ public class CasesService {
                         .orElseThrow(() -> new CasesException(CASE_NOT_FOUND));
 
         if (foundCase.getCaseStatus() != CaseStatus.UNASSIGNED) {
-            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+            throw new CasesException(CasesErrorCode.INVALID_CASE_STATUS);
         }
 
         User attorney =
@@ -139,7 +139,7 @@ public class CasesService {
                         .orElseThrow(() -> new CasesException(CASE_NOT_FOUND));
 
         if (foundCase.getCaseStatus() != CaseStatus.PENDING) {
-            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+            throw new CasesException(CasesErrorCode.INVALID_CASE_STATUS);
         }
 
         // 요청받은 변호사만 조회 가능
@@ -158,7 +158,7 @@ public class CasesService {
                         .orElseThrow(() -> new CasesException(CASE_NOT_FOUND));
 
         if (foundCase.getCaseStatus() != CaseStatus.PENDING) {
-            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+            throw new CasesException(CasesErrorCode.INVALID_CASE_STATUS);
         }
 
         // 요청받은 변호사만 승인/거절 가능
@@ -198,7 +198,7 @@ public class CasesService {
                         .orElseThrow(() -> new CasesException(CASE_NOT_FOUND));
 
         if (foundCase.getCaseStatus() != CaseStatus.IN_PROGRESS) {
-            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+            throw new CasesException(CasesErrorCode.INVALID_CASE_STATUS);
         }
 
         // 변호사는 본인 담당 사건만 확인 가능
@@ -227,7 +227,7 @@ public class CasesService {
         Cases foundCase = getCasesOrThrow(caseId);
 
         if (foundCase.getCaseStatus() != CaseStatus.IN_PROGRESS) {
-            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+            throw new CasesException(CasesErrorCode.INVALID_CASE_STATUS);
         }
 
         // 변호사는 본인 담당 사건만 소장 작성 가능
@@ -261,7 +261,7 @@ public class CasesService {
         Cases foundCase = getCasesOrThrow(caseId);
 
         if (foundCase.getCaseStatus() != CaseStatus.IN_PROGRESS) {
-            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+            throw new CasesException(CasesErrorCode.INVALID_CASE_STATUS);
         }
 
         // 변호사는 본인 담당 사건만 소장 조회 가능
@@ -282,7 +282,7 @@ public class CasesService {
         Cases foundCase = getCasesOrThrow(caseId);
 
         if (foundCase.getCaseStatus() != CaseStatus.IN_PROGRESS) {
-            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+            throw new CasesException(CasesErrorCode.INVALID_CASE_STATUS);
         }
 
         // 변호사는 본인 담당 사건만 소장 수정 가능
@@ -347,7 +347,7 @@ public class CasesService {
         Cases foundCase = getCasesOrThrow(caseId);
 
         if (foundCase.getCaseStatus() != CaseStatus.IN_PROGRESS) {
-            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+            throw new CasesException(CasesErrorCode.INVALID_CASE_STATUS);
         }
 
         // 변호사는 본인 담당 사건만 소송문서 업로드 가능
@@ -387,7 +387,7 @@ public class CasesService {
         Cases foundCase = getCasesOrThrow(caseId);
 
         if (foundCase.getCaseStatus() != CaseStatus.IN_PROGRESS) {
-            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+            throw new CasesException(CasesErrorCode.INVALID_CASE_STATUS);
         }
 
         // 변호사는 본인 담당 사건만 소송문서 조회 가능
@@ -407,7 +407,7 @@ public class CasesService {
         Cases foundCase = getCasesOrThrow(caseId);
 
         if (foundCase.getCaseStatus() != CaseStatus.IN_PROGRESS) {
-            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+            throw new CasesException(CasesErrorCode.INVALID_CASE_STATUS);
         }
 
         // 변호사는 본인 담당 사건만 소송문서 삭제 가능
@@ -439,6 +439,25 @@ public class CasesService {
 
         // 소송문서 삭제
         caseDocumentRepository.delete(caseDocument);
+    }
+
+    //사건 완료처리
+    @Transactional
+    public void completeCase(Long caseId, Long userId) {
+        Cases foundCase = getCasesOrThrow(caseId);
+
+        // 진행중 사건 여부 확인
+        if (foundCase.getCaseStatus() != CaseStatus.IN_PROGRESS) {
+            throw new CasesException(CasesErrorCode.INVALID_CASE_STATUS);
+        }
+
+        // 담당 변호사만 완료 가능
+        if (!foundCase.getAttorney().getId().equals(userId)) {
+            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+        }
+
+        // 상태 변경
+        foundCase.updateStatus(CaseStatus.COMPLETED);
     }
 
 }

--- a/src/main/java/com/haeil/be/cases/service/CasesService.java
+++ b/src/main/java/com/haeil/be/cases/service/CasesService.java
@@ -4,9 +4,12 @@ import static com.haeil.be.cases.exception.errorcode.CasesErrorCode.CASE_NOT_FOU
 
 import com.haeil.be.cases.domain.Cases;
 import com.haeil.be.cases.domain.type.CaseStatus;
+import com.haeil.be.cases.domain.Petition;
 import com.haeil.be.cases.dto.request.AssignAttorneyRequest;
 import com.haeil.be.cases.dto.request.DecisionRequest;
+import com.haeil.be.cases.dto.request.PetitionRequest;
 import com.haeil.be.cases.dto.response.CaseInfoResponse;
+import com.haeil.be.cases.dto.response.PetitionResponse;
 import com.haeil.be.cases.dto.response.OngoingCaseDetailResponse;
 import com.haeil.be.cases.dto.response.OngoingCaseResponse;
 import com.haeil.be.cases.dto.response.RequestedCaseDetailResponse;
@@ -16,6 +19,7 @@ import com.haeil.be.cases.dto.response.UnassignedCaseResponse;
 import com.haeil.be.cases.exception.CasesException;
 import com.haeil.be.cases.exception.errorcode.CasesErrorCode;
 import com.haeil.be.cases.repository.CasesRepository;
+import com.haeil.be.cases.repository.PetitionRepository;
 import com.haeil.be.consultation.domain.Consultation;
 import com.haeil.be.user.domain.User;
 import com.haeil.be.user.repository.UserRepository;
@@ -29,6 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CasesService {
 
     private final CasesRepository casesRepository;
+    private final PetitionRepository petitionRepository;
 
     @Transactional
     public Cases createCaseFromConsultation(Consultation consultation) {
@@ -199,4 +204,124 @@ public class CasesService {
                 .findById(caseId)
                 .orElseThrow(() -> new CasesException(CASE_NOT_FOUND));
     }
+
+    // 소장 작성
+    @Transactional
+    public void createPetition(Long caseId, PetitionRequest request, Long userId) {
+        Cases foundCase = getCasesOrThrow(caseId);
+
+        if (foundCase.getCaseStatus() != CaseStatus.IN_PROGRESS) {
+            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+        }
+
+        // 변호사는 본인 담당 사건만 소장 작성 가능
+        if (foundCase.getAttorney() == null || !foundCase.getAttorney().getId().equals(userId)) {
+            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+        }
+
+        // 이미 소장이 작성되었는지 확인
+        if (foundCase.getPetition() != null) {
+            throw new CasesException(CasesErrorCode.PETITION_ALREADY_EXISTS);
+        }
+
+        Petition petition = Petition.builder()
+                .cases(foundCase)
+                .claimAmount(request.claimAmount())
+                .claimContent(request.claimContent())
+                .accidentCircumstances(request.accidentCircumstances())
+                .damageItems(request.damageItems())
+                .damageCalculation(request.damageCalculation())
+                .liabilityBasis(request.liabilityBasis())
+                .proofMethod(request.proofMethod())
+                .attachedDocuments(request.attachedDocuments())
+                .build();
+
+        petitionRepository.save(petition);
+    }
+
+    // 소장 조회
+    @Transactional(readOnly = true)
+    public PetitionResponse getPetition(Long caseId, Long userId) {
+        Cases foundCase = getCasesOrThrow(caseId);
+
+        if (foundCase.getCaseStatus() != CaseStatus.IN_PROGRESS) {
+            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+        }
+
+        // 변호사는 본인 담당 사건만 소장 조회 가능
+        if (foundCase.getAttorney() == null || !foundCase.getAttorney().getId().equals(userId)) {
+            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+        }
+
+        if (foundCase.getPetition() == null) {
+            throw new CasesException(CasesErrorCode.PETITION_NOT_FOUND);
+        }
+
+        return PetitionResponse.from(foundCase.getPetition());
+    }
+
+    // 소장 수정
+    @Transactional
+    public void updatePetition(Long caseId, PetitionRequest request, Long userId) {
+        Cases foundCase = getCasesOrThrow(caseId);
+
+        if (foundCase.getCaseStatus() != CaseStatus.IN_PROGRESS) {
+            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+        }
+
+        // 변호사는 본인 담당 사건만 소장 수정 가능
+        if (foundCase.getAttorney() == null || !foundCase.getAttorney().getId().equals(userId)) {
+            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+        }
+
+        Petition petition = foundCase.getPetition();
+        if (petition == null) {
+            throw new CasesException(CasesErrorCode.PETITION_NOT_FOUND);
+        }
+
+        // 소장 정보 업데이트
+        updatePetitionFields(petition, request);
+    }
+
+    private void updatePetitionFields(Petition petition, PetitionRequest request) {
+        if (request.claimAmount() != null) {
+            petition.updateClaimAmount(request.claimAmount());
+        }
+        if (request.claimContent() != null) {
+            petition.updateClaimContent(request.claimContent());
+        }
+        if (request.accidentCircumstances() != null) {
+            petition.updateAccidentCircumstances(request.accidentCircumstances());
+        }
+        if (request.damageItems() != null) {
+            petition.updateDamageItems(request.damageItems());
+        }
+        if (request.damageCalculation() != null) {
+            petition.updateDamageCalculation(request.damageCalculation());
+        }
+        if (request.liabilityBasis() != null) {
+            petition.updateLiabilityBasis(request.liabilityBasis());
+        }
+        if (request.proofMethod() != null) {
+            petition.updateProofMethod(request.proofMethod());
+        }
+        if (request.attachedDocuments() != null) {
+            petition.updateAttachedDocuments(request.attachedDocuments());
+        }
+    }
+
+    //법원에서 할당된 사건번호 추가
+    @Transactional
+    public void updateCaseNumber(Long caseId, String caseNumber, Long userId) {
+        Cases foundCase = getCasesOrThrow(caseId);
+
+        // 담당 변호사만 가능
+        if (foundCase.getAttorney() == null || !foundCase.getAttorney().getId().equals(userId)) {
+            throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
+        }
+
+        // 사건번호 업데이트
+        foundCase.updateCaseNumber(caseNumber);
+    }
+
 }

--- a/src/main/java/com/haeil/be/global/config/SecurityConfig.java
+++ b/src/main/java/com/haeil/be/global/config/SecurityConfig.java
@@ -55,7 +55,8 @@ public class SecurityConfig {
                                         .hasRole("SECRETARY")
                                         .requestMatchers(
                                                 "/api/v1/cases/requested/**",
-                                                "/api/v1/cases/ongoing/**")
+                                                "/api/v1/cases/ongoing/**",
+                                                "/api/v1/cases/completed/**")
                                         .hasRole("ATTORNEY")
                                         .anyRequest()
                                         .permitAll())


### PR DESCRIPTION
## 🪺 개요 
진행중 사건 상세보기에 있는 소장 작성부터 완료된 사건 상세보기 API를 구현하였습니다.

## 💻 작업 사항 
> 소장 작성 (첨부서류는 일단 string으로 처리)
> 소장 조회
> 소장 수정
> 정식 사건 번호 등록
> 소송 문서 업로드 (파일 업로드는 일단 FIleService사용)
> 소송 문서 목록 조회
>소송 문서 삭제
>사건 완료 처리
>완료된 사건 목록 조회
>완료된 사건 상세 보기

## 🌱 Issue Number
- #40  <!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요 ?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요 ?
- [ ] 테스트는 잘 통과했나요 ?
- [ ] 빌드에 성공했나요 ?
- [x] 본인을 Assign 해주세요.
- [x] 리뷰할 팀원들을 Request 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙏 To Reviewers
> 진행중인사건 상세보기에서의 종결보고서의 존재 필요 여부가 불분명하여 제외하고 구현을 마쳤습니다. 추후 필요하다 생각되면 아마 완료된 사건에 추가되지 않을까 생각합니다. 기존의 종결보고서를 작성완료해야 완료된사건으로 넘어가는 로직은 PATCH 요청으로 상태변경하여 넘어가도록 하였습니다. 또한 S3를 적용함에 앞서 파일 업로드 부분을 일시적으로 처리했습니다.
