### PR TITLE
[FEAT] 상담 변호사 재배정 기능 개발

### DIFF
--- a/src/main/java/com/haeil/be/consultation/controller/ConsultationController.java
+++ b/src/main/java/com/haeil/be/consultation/controller/ConsultationController.java
@@ -56,7 +56,7 @@ public class ConsultationController {
     }
 
     @Operation(summary = "상담 예약 상세 조회", description = "상담 예약 상세 정보를 조회합니다.")
-    @GetMapping("/requests/{id}")
+    @GetMapping("/reservations/{id}")
     public ApiResponse<Object> getConsultationRequest(@PathVariable Long id) {
         ConsultationReservationResponse response = consultationService.getConsultationRequest(id);
         return ApiResponse.from(response);

--- a/src/main/java/com/haeil/be/consultation/controller/ConsultationController.java
+++ b/src/main/java/com/haeil/be/consultation/controller/ConsultationController.java
@@ -162,4 +162,13 @@ public class ConsultationController {
         List<ConsultationFile> files = consultationService.getConsultationFiles(id);
         return ApiResponse.from(files);
     }
+
+    @Operation(summary = "상담 담당자 변경", description = "진행 중인 상담의 담당 상담사를 변경합니다.")
+    @PatchMapping("/{consultationId}/counselor")
+    public ApiResponse<Object> updateCounselor(
+            @PathVariable Long consultationId,
+            @RequestParam Long newCounselorId) {
+        ConsultationResponse response = consultationService.updateCounselor(consultationId, newCounselorId);
+        return ApiResponse.from(response);
+    }
 }

--- a/src/main/java/com/haeil/be/consultation/domain/Consultation.java
+++ b/src/main/java/com/haeil/be/consultation/domain/Consultation.java
@@ -2,6 +2,8 @@ package com.haeil.be.consultation.domain;
 
 import com.haeil.be.client.domain.Client;
 import com.haeil.be.consultation.domain.type.ConsultationStatus;
+import com.haeil.be.consultation.exception.ConsultationException;
+import com.haeil.be.consultation.exception.errorcode.ConsultationErrorCode;
 import com.haeil.be.global.entity.BaseEntity;
 import com.haeil.be.user.domain.User;
 import jakarta.persistence.*;
@@ -78,5 +80,12 @@ public class Consultation extends BaseEntity {
 
     public User getCounselor() {
         return this.counselor;
+    }
+
+    public void updateCounselor(User newCounselor) {
+        if (!this.isInProgress()) {
+            throw new ConsultationException(ConsultationErrorCode.CONSULTATION_NOT_IN_PROGRESS);
+        }
+        this.counselor = newCounselor;
     }
 }

--- a/src/main/java/com/haeil/be/consultation/service/ConsultationService.java
+++ b/src/main/java/com/haeil/be/consultation/service/ConsultationService.java
@@ -282,4 +282,20 @@ public class ConsultationService {
     public List<ConsultationFile> getConsultationFiles(Long consultationId) {
         return consultationFileRepository.findByConsultationId(consultationId);
     }
+
+    @Transactional
+    public ConsultationResponse updateCounselor(Long consultationId, Long newCounselorId) {
+        Consultation consultation =
+                consultationRepository
+                        .findById(consultationId)
+                        .orElseThrow(
+                                () ->
+                                        new ConsultationException(
+                                                ConsultationErrorCode.CONSULTATION_NOT_FOUND));
+
+        User newCounselor = userService.getUser(newCounselorId);
+        consultation.updateCounselor(newCounselor);
+
+        return ConsultationResponse.from(consultation);
+    }
 }


### PR DESCRIPTION
## 🪺 개요 
Consultation 도메인에 상담 담당자 변경 기능을 추가하여 진행 중인 상담의 담당 변호사를 재배정할 수 있도록 구현했습니다.
- 개발을 시작할 때는 Replit 화면에 맞게 상담 변호사 배정 API가 별도로 필요할거라고 생각했는데,
막상 만들고 나니까 제가 수정한 상담 예약 > 상담 시작 시나리오에서는 필요하지 않습니다.
- 현재 시나리오: `상담 예약 > 승인 > 모든 변호사가 확인 가능 > 상담 시작 버튼을 누르는 상담 변호사가 배정`
- 그래도 기왕 만든거 PR 올릴게요!

## 💻 작업 사항 
  - ConsultationService.java
    - updateCounselor(Long consultationId, Long newCounselorId) 메서드 추가
    - 상담 존재 여부 및 새 상담사 유효성 검증
    - 도메인 메서드 호출을 통한 비즈니스 규칙 적용
  - PATCH /api/v1/consultations/{consultationId}/counselor API 추가
    - @RequestParam Long newCounselorId로 간단한 파라미터 전달

### 별도 수정 사항
  - ConsultationController.java
    - 상담 예약 상세 조회 API 경로 통일
    - /requests/{id} → /reservations/{id} 변경


## 🌱 Issue Number
- #39 

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요 ?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요 ?
- [ ] 테스트는 잘 통과했나요 ?
- [x] 빌드에 성공했나요 ?
- [x] 본인을 Assign 해주세요.
- [x] 리뷰할 팀원들을 Request 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.