### PR TITLE
[FEAT] 수임 관련 API 추가 

### DIFF
--- a/src/main/java/com/haeil/be/cases/controller/CasesController.java
+++ b/src/main/java/com/haeil/be/cases/controller/CasesController.java
@@ -112,8 +112,7 @@ public class CasesController {
     @Operation(summary = "소장 조회", description = "작성된 소장을 조회합니다.")
     @GetMapping("/ongoing/{caseId}/petition")
     public ApiResponse<Object> getPetition(
-            @PathVariable Long caseId,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @PathVariable Long caseId, @AuthenticationPrincipal CustomUserDetails userDetails) {
         return ApiResponse.from(casesService.getPetition(caseId, userDetails.getId()));
     }
 
@@ -128,14 +127,13 @@ public class CasesController {
         return ApiResponse.EMPTY_RESPONSE;
     }
 
-    //법원에서 할당된 사건번호 추가
+    // 법원에서 할당된 사건번호 추가
     @Operation(summary = "사건번호 등록", description = "정식 사건 번호를 추가합니다")
     @PatchMapping("/ongoing/{caseId}/caseNumber")
     public ApiResponse<Object> updateCaseNumber(
             @PathVariable Long caseId,
             @RequestBody CaseNumberRequest request,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
         casesService.updateCaseNumber(caseId, request.caseNumber(), userDetails.getId());
         return ApiResponse.EMPTY_RESPONSE;
     }
@@ -147,7 +145,8 @@ public class CasesController {
             @PathVariable Long caseId,
             @RequestPart("file") MultipartFile file,
             @RequestPart("request") CaseDocumentRequest request,
-            @AuthenticationPrincipal CustomUserDetails userDetails) throws java.io.IOException {
+            @AuthenticationPrincipal CustomUserDetails userDetails)
+            throws java.io.IOException {
         return ApiResponse.from(
                 casesService.uploadCaseDocument(caseId, file, request, userDetails.getId()));
     }
@@ -156,8 +155,7 @@ public class CasesController {
     @Operation(summary = "소송문서 목록 조회", description = "업로드된 소송문서 목록을 조회합니다.")
     @GetMapping("/ongoing/{caseId}/documents")
     public ApiResponse<Object> getCaseDocuments(
-            @PathVariable Long caseId,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @PathVariable Long caseId, @AuthenticationPrincipal CustomUserDetails userDetails) {
         return ApiResponse.from(casesService.getCaseDocuments(caseId, userDetails.getId()));
     }
 
@@ -167,16 +165,17 @@ public class CasesController {
     public ApiResponse<Object> deleteCaseDocument(
             @PathVariable Long caseId,
             @PathVariable Long documentId,
-            @AuthenticationPrincipal CustomUserDetails userDetails) throws java.io.IOException {
+            @AuthenticationPrincipal CustomUserDetails userDetails)
+            throws java.io.IOException {
         casesService.deleteCaseDocument(caseId, documentId, userDetails.getId());
         return ApiResponse.EMPTY_RESPONSE;
     }
-    //사건 완료처리
+
+    // 사건 완료처리
     @Operation(summary = "사건 완료 처리", description = "진행 중 사건을 완료된 사건 상태로 변경합니다.")
     @PatchMapping("/ongoing/{caseId}/complete")
     public ApiResponse<Object> completeCase(
-            @PathVariable Long caseId,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @PathVariable Long caseId, @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         casesService.completeCase(caseId, userDetails.getId());
         return ApiResponse.EMPTY_RESPONSE;

--- a/src/main/java/com/haeil/be/cases/domain/CaseDocument.java
+++ b/src/main/java/com/haeil/be/cases/domain/CaseDocument.java
@@ -35,10 +35,7 @@ public class CaseDocument extends BaseEntity {
 
     @Builder
     public CaseDocument(
-            DocumentType documentType,
-            Cases cases,
-            FileEntity file,
-            String description) {
+            DocumentType documentType, Cases cases, FileEntity file, String description) {
         this.documentType = documentType;
         this.cases = cases;
         this.file = file;

--- a/src/main/java/com/haeil/be/cases/domain/Petition.java
+++ b/src/main/java/com/haeil/be/cases/domain/Petition.java
@@ -21,23 +21,23 @@ public class Petition extends BaseEntity {
     private Cases cases;
 
     // 청구 취지
-    @Column(name = "claim_amount")  //청구금액
+    @Column(name = "claim_amount") // 청구금액
     private Long claimAmount;
 
-    @Column(name = "claim_content", columnDefinition = "TEXT") //청구내용
+    @Column(name = "claim_content", columnDefinition = "TEXT") // 청구내용
     private String claimContent;
 
     // 청구 원인
-    @Column(name = "accident_circumstances", columnDefinition = "TEXT")  //사고경위
+    @Column(name = "accident_circumstances", columnDefinition = "TEXT") // 사고경위
     private String accidentCircumstances;
 
-    @Column(name = "damage_items", columnDefinition = "TEXT")  //손해항목
+    @Column(name = "damage_items", columnDefinition = "TEXT") // 손해항목
     private String damageItems;
 
-    @Column(name = "damage_calculation", columnDefinition = "TEXT")  //손해액상정
+    @Column(name = "damage_calculation", columnDefinition = "TEXT") // 손해액상정
     private String damageCalculation;
 
-    @Column(name = "liability_basis", columnDefinition = "TEXT")  //책임 인정 근거
+    @Column(name = "liability_basis", columnDefinition = "TEXT") // 책임 인정 근거
     private String liabilityBasis;
 
     // 입증 방법
@@ -51,17 +51,17 @@ public class Petition extends BaseEntity {
     @Builder
     public Petition(
             Cases cases,
-            //청구취지
+            // 청구취지
             Long claimAmount,
             String claimContent,
-            //청구원인
+            // 청구원인
             String accidentCircumstances,
             String damageItems,
             String damageCalculation,
             String liabilityBasis,
-            //입증방법
+            // 입증방법
             String proofMethod,
-            //첨부 서류(당장은 string으로 처리했습니다)
+            // 첨부 서류(당장은 string으로 처리했습니다)
             String attachedDocuments) {
         this.cases = cases;
         this.claimAmount = claimAmount;
@@ -106,4 +106,3 @@ public class Petition extends BaseEntity {
         this.attachedDocuments = attachedDocuments;
     }
 }
-

--- a/src/main/java/com/haeil/be/cases/dto/request/CaseDocumentRequest.java
+++ b/src/main/java/com/haeil/be/cases/dto/request/CaseDocumentRequest.java
@@ -2,8 +2,4 @@ package com.haeil.be.cases.dto.request;
 
 import com.haeil.be.cases.domain.type.DocumentType;
 
-public record CaseDocumentRequest(
-        DocumentType documentType,
-        String description
-) {}
-
+public record CaseDocumentRequest(DocumentType documentType, String description) {}

--- a/src/main/java/com/haeil/be/cases/dto/request/CaseNumberRequest.java
+++ b/src/main/java/com/haeil/be/cases/dto/request/CaseNumberRequest.java
@@ -1,5 +1,3 @@
 package com.haeil.be.cases.dto.request;
 
-public record CaseNumberRequest(
-        String caseNumber
-) {}
+public record CaseNumberRequest(String caseNumber) {}

--- a/src/main/java/com/haeil/be/cases/dto/request/PetitionRequest.java
+++ b/src/main/java/com/haeil/be/cases/dto/request/PetitionRequest.java
@@ -12,6 +12,4 @@ public record PetitionRequest(
         // 입증 방법
         String proofMethod,
         // 첨부 서류(일단 string으로 처리했습니다!)
-        String attachedDocuments
-) {}
-
+        String attachedDocuments) {}

--- a/src/main/java/com/haeil/be/cases/dto/response/CaseDocumentResponse.java
+++ b/src/main/java/com/haeil/be/cases/dto/response/CaseDocumentResponse.java
@@ -9,17 +9,16 @@ public record CaseDocumentResponse(
         String originalFilename,
         String fileUrl,
         Long fileSize,
-        String description
-) {
+        String description) {
     public static CaseDocumentResponse from(CaseDocument caseDocument) {
         return new CaseDocumentResponse(
                 caseDocument.getId(),
                 caseDocument.getDocumentType(),
-                caseDocument.getFile() != null ? caseDocument.getFile().getOriginalFilename() : null,
+                caseDocument.getFile() != null
+                        ? caseDocument.getFile().getOriginalFilename()
+                        : null,
                 caseDocument.getFile() != null ? caseDocument.getFile().getFileUrl() : null,
                 caseDocument.getFile() != null ? caseDocument.getFile().getFileSize() : null,
-                caseDocument.getDescription()
-        );
+                caseDocument.getDescription());
     }
 }
-

--- a/src/main/java/com/haeil/be/cases/dto/response/CompletedCaseDetailResponse.java
+++ b/src/main/java/com/haeil/be/cases/dto/response/CompletedCaseDetailResponse.java
@@ -31,4 +31,3 @@ public record CompletedCaseDetailResponse(
                 cases.getCaseEventList().stream().map(CaseEventResponse::from).toList());
     }
 }
-

--- a/src/main/java/com/haeil/be/cases/dto/response/CompletedCaseResponse.java
+++ b/src/main/java/com/haeil/be/cases/dto/response/CompletedCaseResponse.java
@@ -22,4 +22,3 @@ public record CompletedCaseResponse(
                 cases.getAttorney() != null ? cases.getAttorney().getName() : null);
     }
 }
-

--- a/src/main/java/com/haeil/be/cases/dto/response/PetitionResponse.java
+++ b/src/main/java/com/haeil/be/cases/dto/response/PetitionResponse.java
@@ -15,8 +15,7 @@ public record PetitionResponse(
         // 입증 방법
         String proofMethod,
         // 첨부 서류
-        String attachedDocuments
-) {
+        String attachedDocuments) {
     public static PetitionResponse from(Petition petition) {
         return new PetitionResponse(
                 petition.getId(),
@@ -27,8 +26,6 @@ public record PetitionResponse(
                 petition.getDamageCalculation(),
                 petition.getLiabilityBasis(),
                 petition.getProofMethod(),
-                petition.getAttachedDocuments()
-        );
+                petition.getAttachedDocuments());
     }
 }
-

--- a/src/main/java/com/haeil/be/cases/repository/CaseDocumentRepository.java
+++ b/src/main/java/com/haeil/be/cases/repository/CaseDocumentRepository.java
@@ -7,4 +7,3 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface CaseDocumentRepository extends JpaRepository<CaseDocument, Long> {
     List<CaseDocument> findByCasesId(Long caseId);
 }
-

--- a/src/main/java/com/haeil/be/cases/repository/PetitionRepository.java
+++ b/src/main/java/com/haeil/be/cases/repository/PetitionRepository.java
@@ -3,6 +3,4 @@ package com.haeil.be.cases.repository;
 import com.haeil.be.cases.domain.Petition;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PetitionRepository extends JpaRepository<Petition, Long> {
-}
-
+public interface PetitionRepository extends JpaRepository<Petition, Long> {}

--- a/src/main/java/com/haeil/be/cases/service/CasesService.java
+++ b/src/main/java/com/haeil/be/cases/service/CasesService.java
@@ -4,19 +4,19 @@ import static com.haeil.be.cases.exception.errorcode.CasesErrorCode.CASE_NOT_FOU
 
 import com.haeil.be.cases.domain.CaseDocument;
 import com.haeil.be.cases.domain.Cases;
-import com.haeil.be.cases.domain.type.CaseStatus;
 import com.haeil.be.cases.domain.Petition;
+import com.haeil.be.cases.domain.type.CaseStatus;
 import com.haeil.be.cases.dto.request.AssignAttorneyRequest;
 import com.haeil.be.cases.dto.request.CaseDocumentRequest;
 import com.haeil.be.cases.dto.request.DecisionRequest;
 import com.haeil.be.cases.dto.request.PetitionRequest;
 import com.haeil.be.cases.dto.response.CaseDocumentResponse;
 import com.haeil.be.cases.dto.response.CaseInfoResponse;
-import com.haeil.be.cases.dto.response.PetitionResponse;
 import com.haeil.be.cases.dto.response.CompletedCaseDetailResponse;
 import com.haeil.be.cases.dto.response.CompletedCaseResponse;
 import com.haeil.be.cases.dto.response.OngoingCaseDetailResponse;
 import com.haeil.be.cases.dto.response.OngoingCaseResponse;
+import com.haeil.be.cases.dto.response.PetitionResponse;
 import com.haeil.be.cases.dto.response.RequestedCaseDetailResponse;
 import com.haeil.be.cases.dto.response.RequestedCaseResponse;
 import com.haeil.be.cases.dto.response.UnassignedCaseDetailResponse;
@@ -242,17 +242,18 @@ public class CasesService {
             throw new CasesException(CasesErrorCode.PETITION_ALREADY_EXISTS);
         }
 
-        Petition petition = Petition.builder()
-                .cases(foundCase)
-                .claimAmount(request.claimAmount())
-                .claimContent(request.claimContent())
-                .accidentCircumstances(request.accidentCircumstances())
-                .damageItems(request.damageItems())
-                .damageCalculation(request.damageCalculation())
-                .liabilityBasis(request.liabilityBasis())
-                .proofMethod(request.proofMethod())
-                .attachedDocuments(request.attachedDocuments())
-                .build();
+        Petition petition =
+                Petition.builder()
+                        .cases(foundCase)
+                        .claimAmount(request.claimAmount())
+                        .claimContent(request.claimContent())
+                        .accidentCircumstances(request.accidentCircumstances())
+                        .damageItems(request.damageItems())
+                        .damageCalculation(request.damageCalculation())
+                        .liabilityBasis(request.liabilityBasis())
+                        .proofMethod(request.proofMethod())
+                        .attachedDocuments(request.attachedDocuments())
+                        .build();
 
         petitionRepository.save(petition);
     }
@@ -328,7 +329,7 @@ public class CasesService {
         }
     }
 
-    //법원에서 할당된 사건번호 추가
+    // 법원에서 할당된 사건번호 추가
     @Transactional
     public void updateCaseNumber(Long caseId, String caseNumber, Long userId) {
         Cases foundCase = getCasesOrThrow(caseId);
@@ -345,7 +346,8 @@ public class CasesService {
     // 소송문서 업로드
     @Transactional
     public CaseDocumentResponse uploadCaseDocument(
-            Long caseId, MultipartFile file, CaseDocumentRequest request, Long userId) throws IOException {
+            Long caseId, MultipartFile file, CaseDocumentRequest request, Long userId)
+            throws IOException {
         Cases foundCase = getCasesOrThrow(caseId);
 
         if (foundCase.getCaseStatus() != CaseStatus.IN_PROGRESS) {
@@ -371,12 +373,13 @@ public class CasesService {
         }
 
         // 소송문서 생성
-        CaseDocument caseDocument = CaseDocument.builder()
-                .cases(foundCase)
-                .documentType(request.documentType())
-                .file(uploadedFile)
-                .description(request.description())
-                .build();
+        CaseDocument caseDocument =
+                CaseDocument.builder()
+                        .cases(foundCase)
+                        .documentType(request.documentType())
+                        .file(uploadedFile)
+                        .description(request.description())
+                        .build();
 
         caseDocumentRepository.save(caseDocument);
 
@@ -398,9 +401,7 @@ public class CasesService {
         }
 
         List<CaseDocument> documents = caseDocumentRepository.findByCasesId(caseId);
-        return documents.stream()
-                .map(CaseDocumentResponse::from)
-                .collect(Collectors.toList());
+        return documents.stream().map(CaseDocumentResponse::from).collect(Collectors.toList());
     }
 
     // 소송문서 삭제
@@ -417,8 +418,11 @@ public class CasesService {
             throw new CasesException(CasesErrorCode.INVALID_ATTORNEY_ASSIGN);
         }
 
-        CaseDocument caseDocument = caseDocumentRepository.findById(documentId)
-                .orElseThrow(() -> new CasesException(CasesErrorCode.CASE_DOCUMENT_NOT_FOUND));
+        CaseDocument caseDocument =
+                caseDocumentRepository
+                        .findById(documentId)
+                        .orElseThrow(
+                                () -> new CasesException(CasesErrorCode.CASE_DOCUMENT_NOT_FOUND));
 
         // 해당 사건의 문서인지 확인
         if (!caseDocument.getCases().getId().equals(caseId)) {
@@ -443,7 +447,7 @@ public class CasesService {
         caseDocumentRepository.delete(caseDocument);
     }
 
-    //사건 완료처리
+    // 사건 완료처리
     @Transactional
     public void completeCase(Long caseId, Long userId) {
         Cases foundCase = getCasesOrThrow(caseId);
@@ -470,9 +474,7 @@ public class CasesService {
                         .findById(userId)
                         .orElseThrow(() -> new CasesException(CasesErrorCode.ATTORNEY_NOT_FOUND));
 
-        return casesRepository
-                .findByCaseStatusAndAttorney(CaseStatus.COMPLETED, attorney)
-                .stream()
+        return casesRepository.findByCaseStatusAndAttorney(CaseStatus.COMPLETED, attorney).stream()
                 .map(CompletedCaseResponse::from)
                 .toList();
     }
@@ -496,5 +498,4 @@ public class CasesService {
 
         return CompletedCaseDetailResponse.from(foundCase);
     }
-
 }

--- a/src/main/java/com/haeil/be/consultation/controller/ConsultationController.java
+++ b/src/main/java/com/haeil/be/consultation/controller/ConsultationController.java
@@ -166,9 +166,9 @@ public class ConsultationController {
     @Operation(summary = "상담 담당자 변경", description = "진행 중인 상담의 담당 상담사를 변경합니다.")
     @PatchMapping("/{consultationId}/counselor")
     public ApiResponse<Object> updateCounselor(
-            @PathVariable Long consultationId,
-            @RequestParam Long newCounselorId) {
-        ConsultationResponse response = consultationService.updateCounselor(consultationId, newCounselorId);
+            @PathVariable Long consultationId, @RequestParam Long newCounselorId) {
+        ConsultationResponse response =
+                consultationService.updateCounselor(consultationId, newCounselorId);
         return ApiResponse.from(response);
     }
 }

--- a/src/main/java/com/haeil/be/contract/controller/ContractController.java
+++ b/src/main/java/com/haeil/be/contract/controller/ContractController.java
@@ -3,6 +3,7 @@ package com.haeil.be.contract.controller;
 import com.haeil.be.cases.dto.response.CaseInfoResponse;
 import com.haeil.be.cases.service.CasesService;
 import com.haeil.be.contract.dto.request.ContractCreateRequest;
+import com.haeil.be.contract.dto.request.ContractStatusUpdateRequest;
 import com.haeil.be.contract.dto.response.ContractDetailResponse;
 import com.haeil.be.contract.dto.response.ContractItemResponse;
 import com.haeil.be.contract.service.ContractService;
@@ -60,5 +61,17 @@ public class ContractController {
     public ResponseEntity<ApiResponse<Object>> getContractById(@PathVariable Long contractId) {
         ContractDetailResponse response = contractService.getContractDetail(contractId);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.from(response));
+    }
+
+    @Operation(
+            summary = "수임의 상태 변경 API",
+            description =
+                    "contractId를 입력하여 수임 상태를 변경합니다. 가능한 상태는 `AWAITING`, `PENDING`, `COMPLETED` 입니다.")
+    @PatchMapping("/{contractId}/status")
+    public ResponseEntity<ApiResponse<Object>> updateContractStatus(
+            @PathVariable Long contractId,
+            @Valid @RequestBody ContractStatusUpdateRequest request) {
+        contractService.updateStatus(contractId, request);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.EMPTY_RESPONSE);
     }
 }

--- a/src/main/java/com/haeil/be/contract/controller/ContractController.java
+++ b/src/main/java/com/haeil/be/contract/controller/ContractController.java
@@ -40,7 +40,6 @@ public class ContractController {
     public ResponseEntity<ApiResponse<Object>> getContract(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
-        // 추후에 @AuthenticationalPrincipal 사용 예정
         Pageable pageable = PageRequest.of(page, size);
         Page<ContractItemResponse> contractItemResponses =
                 contractService.getContractList(pageable);

--- a/src/main/java/com/haeil/be/contract/domain/Contract.java
+++ b/src/main/java/com/haeil/be/contract/domain/Contract.java
@@ -40,4 +40,8 @@ public abstract class Contract extends BaseEntity {
         this.cases = cases;
         this.expenseInfo = expenseInfo;
     }
+
+    public void updateStatus(ContractStatus newStatus) {
+        this.status = newStatus;
+    }
 }

--- a/src/main/java/com/haeil/be/contract/dto/request/ContractStatusUpdateRequest.java
+++ b/src/main/java/com/haeil/be/contract/dto/request/ContractStatusUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.haeil.be.contract.dto.request;
+
+public record ContractStatusUpdateRequest() {
+}

--- a/src/main/java/com/haeil/be/contract/dto/request/ContractStatusUpdateRequest.java
+++ b/src/main/java/com/haeil/be/contract/dto/request/ContractStatusUpdateRequest.java
@@ -1,4 +1,7 @@
 package com.haeil.be.contract.dto.request;
 
-public record ContractStatusUpdateRequest() {
-}
+import com.haeil.be.contract.domain.type.ContractStatus;
+import com.haeil.be.global.validation.ValidEnum;
+
+public record ContractStatusUpdateRequest(
+        @ValidEnum(enumClass = ContractStatus.class) String contractStatus) {}

--- a/src/main/java/com/haeil/be/contract/exception/errorcode/ContractErrorCode.java
+++ b/src/main/java/com/haeil/be/contract/exception/errorcode/ContractErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum ContractErrorCode implements ErrorCode {
     INVALID_FEE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 계약유형입니다."),
     CONTRACT_NOT_FOUND(HttpStatus.NOT_FOUND, "수임 계약이 존재하지 않습니다."),
+    CAN_NOT_CHANGE_STATUS(HttpStatus.BAD_REQUEST, "같은 상태로는 변경할 수 없습니다."),
     CONDITION_SHOULD_NOT_BE_NULL(HttpStatus.BAD_REQUEST, "정액 계약은 보수 조건 목록이 비어있을 수 없습니다."),
     ;
 

--- a/src/main/java/com/haeil/be/contract/service/ContractService.java
+++ b/src/main/java/com/haeil/be/contract/service/ContractService.java
@@ -14,6 +14,7 @@ import com.haeil.be.contract.domain.type.ContractStatus;
 import com.haeil.be.contract.domain.type.FeeType;
 import com.haeil.be.contract.dto.request.ContractConditionRequest;
 import com.haeil.be.contract.dto.request.ContractCreateRequest;
+import com.haeil.be.contract.dto.request.ContractStatusUpdateRequest;
 import com.haeil.be.contract.dto.request.ExpenseInfoRequest;
 import com.haeil.be.contract.dto.response.ContractDetailResponse;
 import com.haeil.be.contract.dto.response.ContractItemResponse;
@@ -64,6 +65,17 @@ public class ContractService {
         return ContractDetailResponse.from(contract);
     }
 
+    @Transactional
+    public void updateStatus(Long contractId, ContractStatusUpdateRequest request) {
+        Contract contract = findContractOrThrow(contractId);
+        ContractStatus currentStatus = contract.getStatus();
+        ContractStatus targetStatus = ContractStatus.valueOf(request.contractStatus());
+        if (!isValidStatusTransition(currentStatus, targetStatus)) {
+            throw new ContractException(CAN_NOT_CHANGE_STATUS);
+        }
+        contract.updateStatus(targetStatus);
+    }
+
     private Cases findCasesOrThrow(Long caseId) {
         return casesRepository
                 .findById(caseId)
@@ -78,6 +90,14 @@ public class ContractService {
         return contractRepository
                 .findById(contractId)
                 .orElseThrow(() -> new ContractException(CONTRACT_NOT_FOUND));
+    }
+
+    private boolean isValidStatusTransition(
+            ContractStatus currentStatus, ContractStatus targetStatus) {
+        if (currentStatus == targetStatus) {
+            return false;
+        }
+        return true;
     }
 
     // 정액 계약 생성 로직

--- a/src/main/java/com/haeil/be/global/config/SecurityConfig.java
+++ b/src/main/java/com/haeil/be/global/config/SecurityConfig.java
@@ -51,7 +51,8 @@ public class SecurityConfig {
                                                 "/api/v1/auth/signup",
                                                 "/api/v1/auth/login")
                                         .permitAll()
-                                        .requestMatchers("/api/v1/contract/**")
+                                        .requestMatchers(
+                                                "/api/v1/contract/**", "/api/v1/settlements/**")
                                         .hasRole("ACCOUNT")
                                         .requestMatchers("/api/v1/cases/unassigned/**")
                                         .hasRole("SECRETARY")

--- a/src/main/java/com/haeil/be/global/config/SecurityConfig.java
+++ b/src/main/java/com/haeil/be/global/config/SecurityConfig.java
@@ -51,6 +51,8 @@ public class SecurityConfig {
                                                 "/api/v1/auth/signup",
                                                 "/api/v1/auth/login")
                                         .permitAll()
+                                        .requestMatchers("/api/v1/contract/**")
+                                        .hasRole("ACCOUNT")
                                         .requestMatchers("/api/v1/cases/unassigned/**")
                                         .hasRole("SECRETARY")
                                         .requestMatchers(

--- a/src/main/java/com/haeil/be/global/config/SecurityConfig.java
+++ b/src/main/java/com/haeil/be/global/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package com.haeil.be.global.config;
 
 import com.haeil.be.auth.filter.JwtAuthFilter;
 import com.haeil.be.auth.util.JwtTokenProvider;
+import com.haeil.be.global.exception.handler.CustomAccessDeniedHandler;
+import com.haeil.be.global.exception.handler.CustomAuthenticationEntryPoint;
 import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -25,6 +27,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @Bean
     public SecurityFilterChain filterChain(
@@ -35,6 +39,11 @@ public class SecurityConfig {
                         session ->
                                 session.sessionCreationPolicy(
                                         SessionCreationPolicy.STATELESS)) // 세션 비활성화
+                .exceptionHandling(
+                        exceptionHandler ->
+                                exceptionHandler
+                                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                                        .accessDeniedHandler(customAccessDeniedHandler))
                 .authorizeHttpRequests(
                         authorize ->
                                 authorize

--- a/src/main/java/com/haeil/be/global/exception/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/haeil/be/global/exception/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,29 @@
+package com.haeil.be.global.exception.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.haeil.be.global.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException)
+            throws IOException {
+        ApiResponse<Object> errorResponse = ApiResponse.JSON_ROLE_ERROR;
+
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN); // 403
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/haeil/be/global/exception/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/haeil/be/global/exception/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package com.haeil.be.global.exception.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.haeil.be.global.response.ApiResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException)
+            throws IOException, ServletException {
+
+        ApiResponse<Object> errorResponse = ApiResponse.JSON_AUTH_ERROR;
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}


### PR DESCRIPTION
## 🪺 개요 
수임 관련 상태 변경 API를 추가 구현했습니다. 

## 💻 작업 사항 
1. 수임 관련 상태 변경 API를 구현했습니다. 
- dto 필드에 ValidEnum을 사용하였습니다. 코드 리뷰할 때는 못봤었는데 주영님이 구현해놓으셨더라고요👍🏻 

2. Spring Security에서 발생하는 인증 및 인가 실패 시에 클라이언트에게 일관된 JSON 형식의 오류 응답을 제공하도록 설정했습니다. 앞으로는 로그인을 하지 않았을 경우나 JWT 토큰이 없거나 만료된 경우, 해당 사용자의 권한 (role)이 접근 권한을 충족시키지 못할 경우 JSON 형태의 에러 메시지를 반환합니다. 
- CustomAuthenticationEntryPoint 
- CustomAccessDeniedHandler 

3. 앞서 코드 포맷팅이 적용되지 않은 부분이 있어서 전체에 적용시켰습니다. Case 부분이나 Petition 부분 코드 리뷰는 하지 않으셔도 됩니다. 

## 🌱 Issue Number
- #50 

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요 ?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요 ?
- [x] 테스트는 잘 통과했나요 ?
- [x] 빌드에 성공했나요 ?
- [x] 본인을 Assign 해주세요.
- [x] 리뷰할 팀원들을 Request 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙏 To Reviewers
> 앞서 코드 포맷팅이 적용되지 않은 부분이 있어서 전체에 적용시켰습니다. Case 부분이나 Petition 부분 코드 리뷰는 하지 않으셔도 됩니다. 

