### PR TITLE
Feat/calender adapter #60

### DIFF
--- a/src/main/java/com/haeil/full/calendar/adapter/CalendarEventAdapter.java
+++ b/src/main/java/com/haeil/full/calendar/adapter/CalendarEventAdapter.java
@@ -8,3 +8,4 @@ import java.util.List;
 public interface CalendarEventAdapter {
     List<CalendarEvent> getEvents(LocalDateTime start, LocalDateTime end, User user);
 }
+

--- a/src/main/java/com/haeil/full/calendar/adapter/CaseEventAdapter.java
+++ b/src/main/java/com/haeil/full/calendar/adapter/CaseEventAdapter.java
@@ -1,0 +1,72 @@
+package com.haeil.full.calendar.adapter;
+
+import com.haeil.full.calendar.domain.CalendarEvent;
+import com.haeil.full.cases.domain.CaseEvent;
+import com.haeil.full.cases.domain.type.CaseStatus;
+import com.haeil.full.cases.repository.CaseEventRepository;
+import com.haeil.full.user.domain.User;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CaseEventAdapter implements CalendarEventAdapter {
+
+    private final CaseEventRepository caseEventRepository;
+
+    @Override
+    public List<CalendarEvent> getEvents(LocalDateTime start, LocalDateTime end, User user) {
+        if (user == null) {
+            return List.of();
+        }
+
+        List<CaseEvent> caseEvents =
+                caseEventRepository.findAllByDateBetweenAndAttorney(start, end, user);
+
+        return caseEvents.stream().map(this::toCalendarEvent).collect(Collectors.toList());
+    }
+
+    private CalendarEvent toCalendarEvent(CaseEvent caseEvent) {
+        String caseTitle =
+                caseEvent.getCases() != null ? caseEvent.getCases().getTitle() : "Unknown Case";
+        String eventTypeLabel =
+                caseEvent.getType() != null ? caseEvent.getType().getLabel() : "기일";
+        String title = String.format("[%s] %s", eventTypeLabel, caseTitle);
+
+        Long caseId = null;
+        String caseStatus = null;
+
+        if (caseEvent.getCases() != null) {
+            caseId = caseEvent.getCases().getId();
+            CaseStatus status = caseEvent.getCases().getCaseStatus();
+            if (status != null) {
+                caseStatus = status.name(); // ONGOING, COMPLETED, etc.
+            }
+        }
+
+        Map<String, Object> props = new HashMap<>();
+        if (caseId != null) {
+            props.put("caseId", caseId);
+        }
+        if (caseStatus != null) {
+            props.put("status", caseStatus);
+        }
+
+        return CalendarEvent.builder()
+                .id("case_" + caseEvent.getId())
+                .title(title)
+                .start(caseEvent.getDate())
+                // 기일은 보통 1시간 정도로 가정하거나, 별도 종료 시간이 있다면 사용
+                .end(caseEvent.getDate().plusHours(1))
+                .className("bg-danger-subtle text-danger") // 사건 기일은 붉은색 계열로 표시
+                .type("CASE_EVENT")
+                .allDay(false)
+                .extendedProps(props)
+                .build();
+    }
+}

--- a/src/main/java/com/haeil/full/calendar/adapter/ContractEventAdapter.java
+++ b/src/main/java/com/haeil/full/calendar/adapter/ContractEventAdapter.java
@@ -1,0 +1,53 @@
+package com.haeil.full.calendar.adapter;
+
+import com.haeil.full.calendar.domain.CalendarEvent;
+import com.haeil.full.contract.domain.Contract;
+import com.haeil.full.contract.repository.ContractRepository;
+import com.haeil.full.user.domain.User;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ContractEventAdapter implements CalendarEventAdapter {
+
+    private final ContractRepository contractRepository;
+
+    @Override
+    public List<CalendarEvent> getEvents(LocalDateTime start, LocalDateTime end, User user) {
+        if (user == null) {
+            return List.of();
+        }
+
+        List<Contract> contracts =
+                contractRepository.findAllByDueDateBetweenAndAttorney(
+                        start.toLocalDate(), end.toLocalDate(), user);
+
+        return contracts.stream().map(this::toCalendarEvent).collect(Collectors.toList());
+    }
+
+    private CalendarEvent toCalendarEvent(Contract contract) {
+        String caseTitle =
+                contract.getCases() != null ? contract.getCases().getTitle() : "Unknown Case";
+        String title = String.format("[계약] %s", caseTitle);
+        
+        // 계약 기한은 자정으로 설정
+        LocalDateTime dueDate = contract.getDueDate().atStartOfDay();
+
+        return CalendarEvent.builder()
+                .id("contract_" + contract.getId())
+                .title(title)
+                .start(dueDate)
+                .end(dueDate) // 마감일은 하루 전체 이벤트로 보거나 start와 같게 설정
+                .className("bg-warning-subtle text-warning") // 계약은 노란색 계열
+                .type("CONTRACT")
+                .allDay(true) // 기한은 보통 날짜 단위
+                .extendedProps(Map.of("contractId", contract.getId()))
+                .build();
+    }
+}
+

--- a/src/main/java/com/haeil/full/calendar/adapter/SettlementEventAdapter.java
+++ b/src/main/java/com/haeil/full/calendar/adapter/SettlementEventAdapter.java
@@ -1,0 +1,52 @@
+package com.haeil.full.calendar.adapter;
+
+import com.haeil.full.calendar.domain.CalendarEvent;
+import com.haeil.full.settlement.domain.Settlement;
+import com.haeil.full.settlement.repository.SettlementRepository;
+import com.haeil.full.user.domain.User;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SettlementEventAdapter implements CalendarEventAdapter {
+
+    private final SettlementRepository settlementRepository;
+
+    @Override
+    public List<CalendarEvent> getEvents(LocalDateTime start, LocalDateTime end, User user) {
+        if (user == null) {
+            return List.of();
+        }
+
+        List<Settlement> settlements =
+                settlementRepository.findAllByPaymentDueDateBetweenAndAttorney(
+                        start.toLocalDate(), end.toLocalDate(), user);
+
+        return settlements.stream().map(this::toCalendarEvent).collect(Collectors.toList());
+    }
+
+    private CalendarEvent toCalendarEvent(Settlement settlement) {
+        String caseTitle =
+                settlement.getCases() != null ? settlement.getCases().getTitle() : "Unknown Case";
+        String title = String.format("[정산] %s 입금기한", caseTitle);
+
+        LocalDateTime dueDate = settlement.getPaymentDueDate().atStartOfDay();
+
+        return CalendarEvent.builder()
+                .id("settlement_" + settlement.getId())
+                .title(title)
+                .start(dueDate)
+                .end(dueDate)
+                .className("bg-success-subtle text-success") // 정산/입금은 초록색 계열
+                .type("SETTLEMENT")
+                .allDay(true)
+                .extendedProps(Map.of("settlementId", settlement.getId()))
+                .build();
+    }
+}
+

--- a/src/main/java/com/haeil/full/calendar/domain/CalendarEvent.java
+++ b/src/main/java/com/haeil/full/calendar/domain/CalendarEvent.java
@@ -17,3 +17,4 @@ public class CalendarEvent {
     private boolean allDay;
     private Map<String, Object> extendedProps;
 }
+

--- a/src/main/java/com/haeil/full/calendar/service/CalendarService.java
+++ b/src/main/java/com/haeil/full/calendar/service/CalendarService.java
@@ -22,3 +22,4 @@ public class CalendarService {
                 .collect(Collectors.toList());
     }
 }
+

--- a/src/main/java/com/haeil/full/cases/repository/CaseEventRepository.java
+++ b/src/main/java/com/haeil/full/cases/repository/CaseEventRepository.java
@@ -1,0 +1,23 @@
+package com.haeil.full.cases.repository;
+
+import com.haeil.full.cases.domain.CaseEvent;
+import com.haeil.full.user.domain.User;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CaseEventRepository extends JpaRepository<CaseEvent, Long> {
+
+    @Query(
+            "SELECT ce FROM CaseEvent ce "
+                    + "JOIN ce.cases c "
+                    + "WHERE ce.date BETWEEN :start AND :end "
+                    + "AND c.attorney = :attorney")
+    List<CaseEvent> findAllByDateBetweenAndAttorney(
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            @Param("attorney") User attorney);
+}
+

--- a/src/main/java/com/haeil/full/contract/repository/ContractRepository.java
+++ b/src/main/java/com/haeil/full/contract/repository/ContractRepository.java
@@ -1,6 +1,22 @@
 package com.haeil.full.contract.repository;
 
 import com.haeil.full.contract.domain.Contract;
+import com.haeil.full.user.domain.User;
+import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface ContractRepository extends JpaRepository<Contract, Long> {}
+public interface ContractRepository extends JpaRepository<Contract, Long> {
+
+    @Query(
+            "SELECT c FROM Contract c "
+                    + "JOIN c.cases cs "
+                    + "WHERE c.dueDate BETWEEN :start AND :end "
+                    + "AND cs.attorney = :attorney")
+    List<Contract> findAllByDueDateBetweenAndAttorney(
+            @Param("start") LocalDate start,
+            @Param("end") LocalDate end,
+            @Param("attorney") User attorney);
+}

--- a/src/main/java/com/haeil/full/global/controller/GlobalControllerAdvice.java
+++ b/src/main/java/com/haeil/full/global/controller/GlobalControllerAdvice.java
@@ -59,3 +59,4 @@ public class GlobalControllerAdvice {
     }
 }
 
+

--- a/src/main/java/com/haeil/full/settlement/repository/SettlementRepository.java
+++ b/src/main/java/com/haeil/full/settlement/repository/SettlementRepository.java
@@ -2,6 +2,8 @@ package com.haeil.full.settlement.repository;
 
 import com.haeil.full.cases.domain.type.CaseStatus;
 import com.haeil.full.settlement.domain.Settlement;
+import com.haeil.full.user.domain.User;
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -21,4 +23,14 @@ public interface SettlementRepository extends JpaRepository<Settlement, Long> {
                     + "ORDER BY c.createdDate DESC")
     List<Object[]> findSettlementsByCaseStatuses(
             @Param("caseStatuses") List<CaseStatus> caseStatuses);
+
+    @Query(
+            "SELECT s FROM Settlement s "
+                    + "JOIN s.cases c "
+                    + "WHERE s.paymentDueDate BETWEEN :start AND :end "
+                    + "AND c.attorney = :attorney")
+    List<Settlement> findAllByPaymentDueDateBetweenAndAttorney(
+            @Param("start") LocalDate start,
+            @Param("end") LocalDate end,
+            @Param("attorney") User attorney);
 }

--- a/src/main/resources/static/js/pages/apps-calendar.js
+++ b/src/main/resources/static/js/pages/apps-calendar.js
@@ -10,6 +10,7 @@ class CalendarSchedule {
     constructor() {
         this.calendar = document.getElementById('calendar');
         this.calendarObj = null;
+        this.allEvents = []; // 로드된 전체 이벤트 저장용
     }
 
     init() {
@@ -42,12 +43,19 @@ class CalendarSchedule {
                 center: 'title',
                 right: 'dayGridMonth,timeGridWeek,timeGridDay,listMonth'
             },
-            events: {
-                url: '/api/calendar/events',
-                method: 'GET',
-                failure: function() {
-                    alert('일정을 불러오는 중 오류가 발생했습니다.');
-                }
+            events: function(info, successCallback, failureCallback) {
+                // API 호출
+                fetch(`/api/calendar/events?start=${info.startStr}&end=${info.endStr}`)
+                    .then(response => response.json())
+                    .then(data => {
+                        self.allEvents = data; // 원본 데이터 저장
+                        const filteredEvents = self.filterEvents(data);
+                        successCallback(filteredEvents);
+                    })
+                    .catch(error => {
+                        console.error('Error fetching events:', error);
+                        failureCallback(error);
+                    });
             },
             editable: false,
             droppable: false,
@@ -61,14 +69,63 @@ class CalendarSchedule {
                     if (type === 'consultation') {
                         window.location.href = '/consultations/' + id;
                     } else if (type === 'case') {
-                        // 추후 사건 상세 페이지 구현 시 연결
-                        // window.location.href = '/cases/' + id;
+                        // CaseEventAdapter에서 extendedProps에 caseId와 status를 담아줌
+                        const props = info.event.extendedProps;
+                        if (props && props.caseId) {
+                             let urlPath = 'ongoing'; // 기본값
+                             if (props.status === 'COMPLETED') {
+                                 urlPath = 'completed';
+                             } else if (props.status === 'UNASSIGNED') {
+                                 urlPath = 'unassigned';
+                             }
+                             // 그 외(ONGOING 등)는 ongoing으로 이동
+                             
+                             window.location.href = '/cases/' + urlPath + '/' + props.caseId;
+                        }
+                    } else if (type === 'contract') {
+                        const props = info.event.extendedProps;
+                        if (props && props.contractId) {
+                            // 계약 상세 페이지 경로 (예시)
+                            // window.location.href = '/contracts/' + props.contractId;
+                            // 현재는 계약 목록으로 이동하되, 추후 상세 구현 시 변경
+                             window.location.href = '/contracts';
+                        }
+                    } else if (type === 'settlement') {
+                        const props = info.event.extendedProps;
+                        if (props && props.settlementId) {
+                             window.location.href = '/settlements/' + props.settlementId;
+                        }
                     }
                 }
             }
         });
 
         self.calendarObj.render();
+
+        // 필터 체크박스 이벤트 리스너 등록
+        const filterCheckboxes = document.querySelectorAll('.filter-checkbox');
+        filterCheckboxes.forEach(checkbox => {
+            checkbox.addEventListener('change', () => {
+                // 현재 뷰에 있는 이벤트들을 메모리 상에서 다시 필터링하여 렌더링
+                // refetchEvents를 호출하면 events 함수가 다시 실행되어 API를 호출하게 됨.
+                // 여기서는 API 재호출 없이 필터링만 하고 싶다면 다른 방식을 써야 하지만,
+                // FullCalendar 구조상 refetch가 가장 깔끔함 (events 함수 내에서 캐싱 로직 구현 가능하나 생략)
+                self.calendarObj.refetchEvents();
+            });
+        });
+    }
+    
+    // 이벤트 필터링 헬퍼 함수
+    filterEvents(events) {
+        const activeFilters = Array.from(document.querySelectorAll('.filter-checkbox:checked'))
+                                   .map(cb => cb.value); // ['CONSULTATION', 'CASE_EVENT', ...]
+        
+        return events.filter(event => {
+            // event.type은 CalendarEvent DTO의 type 필드 (CONSULTATION, CASE_EVENT, CONTRACT, SETTLEMENT)
+            // FullCalendar event object에서는 extendedProps로 접근해야 할 수 있음.
+            // 하지만 API 응답 JSON 자체(events)를 필터링하는 것이므로 DTO 구조를 따름.
+            return activeFilters.includes(event.type);
+        });
     }
 
 }

--- a/src/main/resources/templates/pages/index.html
+++ b/src/main/resources/templates/pages/index.html
@@ -17,7 +17,27 @@
                 <div class="col-12">
                     <div class="outlook-box">
                         <div class="card h-100 mb-0 rounded-start-0 flex-grow-1 border-start-0">
-                            <div class="card-body" style="height: calc(100% - 350px);" data-simplebar data-simplebar-md>
+                            <div class="card-body border-bottom">
+                                <div class="d-flex align-items-center gap-3">
+                                    <div class="form-check form-check-inline">
+                                        <input class="form-check-input filter-checkbox" type="checkbox" id="filterConsultation" value="CONSULTATION" checked>
+                                        <label class="form-check-label text-primary" for="filterConsultation">상담</label>
+                                    </div>
+                                    <div class="form-check form-check-inline">
+                                        <input class="form-check-input filter-checkbox" type="checkbox" id="filterCase" value="CASE_EVENT" checked>
+                                        <label class="form-check-label text-danger" for="filterCase">사건(재판)</label>
+                                    </div>
+                                    <div class="form-check form-check-inline">
+                                        <input class="form-check-input filter-checkbox" type="checkbox" id="filterContract" value="CONTRACT" checked>
+                                        <label class="form-check-label text-warning" for="filterContract">계약</label>
+                                    </div>
+                                    <div class="form-check form-check-inline">
+                                        <input class="form-check-input filter-checkbox" type="checkbox" id="filterSettlement" value="SETTLEMENT" checked>
+                                        <label class="form-check-label text-success" for="filterSettlement">정산</label>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="card-body" style="height: calc(100% - 400px);" data-simplebar data-simplebar-md>
                                 <div id="calendar"></div>
                             </div>
                         </div>


### PR DESCRIPTION
## 🪺 개요
사건(재판), 수임, 정산 Adapter를 추가로 개발했습니다.

## 💻 작업 사항
1. 캘린더 서비스 추가
각 도메인별(Case, Contract, Settlement)로 구현체를 추가로 개발했습니다.

2. 도메인별 일정 연동
사건(Case) 기일: CaseEventAdapter를 구현하여 변론기일, 공판기일 등을 붉은색(bg-danger)으로 표시합니다.
계약(Contract) 기한: ContractEventAdapter를 구현하여 계약 마감일(dueDate)을 노란색(bg-warning)으로 표시합니다.
정산(Settlement) 입금기한: SettlementEventAdapter를 구현하여 입금 예정일(paymentDueDate)을 초록색(bg-success)으로 표시합니다.

3. 프론트엔드 기능 개선
일정 필터링: 캘린더 상단에 체크박스(상담, 사건, 계약, 정산)를 추가하여 원하는 일정만 선택적으로 볼 수 있도록 구현했습니다.
사건의 상태(진행중/완료/미배정)나 업무 유형에 따라 정확한 상세 페이지로 이동하도록 로직을 작성했습니다.

## 🌱 Issue Number
- #60 

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요 ?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요 ?
- [ ] 테스트는 잘 통과했나요 ?
- [x] 빌드에 성공했나요 ?
- [x] 본인을 Assign 해주세요.
- [x] 리뷰할 팀원들을 Request 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.
