### PR TITLE
[BUG] DB커넥션 점유 문제 해결

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
+    open-in-view: false
     hibernate:
       ddl-auto: update
 


### PR DESCRIPTION
## 🪺 개요 
제가 sse 연결로직을 잘못 알고 있었습니다. 사용자가 페이지를 이동하거나 새로고침하면 notification.js를 새로 읽어서 자동으로 SSE연결을 시도합니다. 그래서 페이지를 이동할 때마다 새롭게 subscribing이 찍히는 거였어요. 


### **문제상황**
설정된 DB 커넥션 풀(HikariPool)의 최대 개수는 10개인데 그 이상 요청부터는 남은 커넥션이 없어서 JDBCConnectionException이 발생

**Caused by: org.hibernate.exception.JDBCConnectionException: Unable to acquire JDBC Connection [HikariPool-1 - Connection is not available, request timed out after 30007ms (total=10, active=10, idle=0, waiting=0)] [n/a]**

## 💻 작업 사항 
application.yml을 수정하여 SSE 연결 중에도 DB 커넥션을 잡고 있지 않도록 하였습니다.
SSE 구독 요청(subscribe) 처리가 끝나면 즉시 DB 커넥션을 반납합니다.

## 🌱 Issue Number
- #70  <!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->

## ✅ 셀프 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했나요 ?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요 ?
- [ ] 테스트는 잘 통과했나요 ?
- [ ] 빌드에 성공했나요 ?
- [ ] 본인을 Assign 해주세요.
- [ ] 리뷰할 팀원들을 Request 해주세요.
- [ ] 해당 PR에 맞는 label을 붙여주세요.

## 🙏 To Reviewers
>
